### PR TITLE
feat(topology): add Deref to TopologyWriteGuard for read-through access

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,10 +20,19 @@ classDiagram
         -inner: Arc~RwLock~TopologyState~~
         -events: broadcast::Sender~TopologyEvent~
         +new() Topology
-        +read() Result~TopologyReadGuard~
-        +merge(remove, add) Result
-        +merge_unchecked(remove, add) Result
+        +with_event_capacity(capacity) Topology
+        +read() TopologyReadGuard
+        +write() TopologyWriteGuard
         +subscribe() Receiver~TopologyEvent~
+    }
+
+    class TopologyWriteGuard {
+        +add_component(component)
+        +add_app(app)
+        +add_area(area)
+        +remove_component(id)
+        +remove_app(id)
+        +remove_area(id)
     }
 
     class TopologyReadGuard {
@@ -126,6 +135,7 @@ classDiagram
     Server --> Authenticator : uses
     Server --> Authorizer : uses
     Topology --> TopologyReadGuard : produces
+    Topology --> TopologyWriteGuard : produces
     TopologyReadGuard --> Component : queries
     TopologyReadGuard --> App : queries
     TopologyReadGuard --> Area : queries
@@ -151,13 +161,19 @@ The main entry point for the OpenSOVD application. Built using a builder pattern
 
 ### Topology
 
-A thread-safe registry for components, apps, and areas. Wraps an `Arc<RwLock<TopologyState>>` where the state holds three `IndexMap` collections (one per entity kind) plus relationship indexes (`apps_by_component`, `components_by_area`, `apps_by_area`). Reading is done through `read()` which returns a `TopologyReadGuard` holding a single read lock for consistent multi-query access. Mutations use `merge()` (validates no duplicates or missing removals) or `merge_unchecked()` (silently skips missing removals, overwrites duplicates). Both emit `TopologyEvent::Added` / `TopologyEvent::Removed` via a `broadcast` channel. Callers can `subscribe()` to receive these events.
+A thread-safe registry for components, apps, and areas. Wraps an `Arc<RwLock<TopologyState>>` where the state holds three `IndexMap` collections (one per entity kind) plus relationship indexes (`apps_by_component`, `components_by_area`, `apps_by_area`). Reading is done through `read()` which returns a `TopologyReadGuard` holding a single read lock for consistent multi-query access. Mutations are done through `write()` which returns a `TopologyWriteGuard` holding a single write lock; `add_*` overwrites an existing entry with the same ID and `remove_*` silently skips missing IDs. `TopologyEvent::Added` / `TopologyEvent::Removed` events are batched on the guard and flushed via a `broadcast` channel when the guard is dropped. Callers can `subscribe()` to receive these events.
 
 **Crate:** `opensovd-core`
 
 ### TopologyReadGuard
 
 A read guard over the topology state. Holds a `RwLockReadGuard` for its lifetime, ensuring a consistent snapshot across multiple queries. Provides `get_component()`, `get_app()`, `get_area()` for single-entity lookup, `components()`, `apps()`, `areas()` for listing, and relationship queries: `apps_of_component()`, `components_of_area()`, `apps_of_area()`, `component_of_app()`, `area_of_component()`, `area_of_app()`.
+
+**Crate:** `opensovd-core`
+
+### TopologyWriteGuard
+
+A write guard over the topology state. Holds a `RwLockWriteGuard` for its lifetime so a batch of mutations applies atomically. Provides `add_component()`, `add_app()`, `add_area()` (each overwrites an existing entry with the same ID) and `remove_component()`, `remove_app()`, `remove_area()` (each silently skips missing IDs). Topology events are accumulated in the guard and flushed to the broadcast channel when the guard is dropped.
 
 **Crate:** `opensovd-core`
 

--- a/opensovd-core/src/topology.rs
+++ b/opensovd-core/src/topology.rs
@@ -285,6 +285,14 @@ pub struct TopologyWriteGuard<'a> {
     pending: Vec<TopologyEvent>,
 }
 
+impl Deref for TopologyWriteGuard<'_> {
+    type Target = TopologyState;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
 impl TopologyWriteGuard<'_> {
     /// Adds a component. Overwrites an existing entry with the same ID.
     pub fn add_component(&mut self, component: Component) {
@@ -706,6 +714,15 @@ mod tests {
         topology.write().await.remove_area("network");
 
         assert_eq!(topology.read().await.apps_of_area("network").count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_write_guard_read_through_deref() {
+        let topology = Topology::new();
+        let mut t = topology.write().await;
+        t.add_component(Component::new("ecu1", "ECU 1"));
+        assert_eq!(t.get_component("ecu1").unwrap().id(), "ecu1");
+        assert_eq!(t.components().len(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
add Deref to TopologyWriteGuard for read-through access

Implement Deref<Target = TopologyState> on TopologyWriteGuard so callers
holding a write guard can invoke read-side methods (get_component,
components, etc.) without releasing the lock and re-acquiring a read
guard. This keeps batched mutations and their follow-up reads within a
single atomic critical section.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests