### PR TITLE
ci(deps): consolidate dependabot to monthly grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,14 @@ updates:
           - "*"
     commit-message:
       prefix: "chore(deps)"
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      cargo:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,14 @@ updates:
           - "*"
     commit-message:
       prefix: "chore(deps)"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      python:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       actions:
         patterns:


### PR DESCRIPTION
## Summary
Reduce dependabot noise by moving all ecosystems to a monthly grouped cadence and extending coverage to Python and Rust.

  - Switch `github-actions` updates from weekly to monthly (group unchanged)
  - Add `pip` ecosystem for the root `pyproject.toml`, grouped under `python` with a `chore(deps)` prefix
  - Add `cargo` ecosystem for the workspace, grouped under `cargo` with a `chore(deps)` prefix

  ## Checklist
  - [x] I have tested my changes locally