### PR TITLE
chore(github): add CODEOWNERS for automotive-opensovd-committers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+*       @eclipse-opensovd/automotive-opensovd-committers


### PR DESCRIPTION
## Summary
  Adds `.github/CODEOWNERS` assigning whole-repo ownership to
  `@eclipse-opensovd/automotive-opensovd-committers`

  ## Checklist
  - [x] I have tested my changes locally
  - [x] I have added or updated documentation
  - [x] I have linked related issues or discussions
  - [x] I have added or updated tests

  ## Related
  Mirrors `eclipse-opensovd/classic-diagnostic-adapter` CODEOWNERS.