### PR TITLE
fix: align gateway --url form and example ports

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,5 +8,5 @@ COPY target/release-small/${TARGETARCH}/opensovd-gateway /usr/local/bin/opensovd
 
 EXPOSE 7690
 
+ENV SOVD_URL=http://0.0.0.0:7690/sovd
 ENTRYPOINT ["/usr/local/bin/opensovd-gateway"]
-CMD ["--url", "http://0.0.0.0:7690/sovd"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,4 +9,4 @@ COPY target/release-small/${TARGETARCH}/opensovd-gateway /usr/local/bin/opensovd
 EXPOSE 7690
 
 ENTRYPOINT ["/usr/local/bin/opensovd-gateway"]
-CMD ["--url", "0.0.0.0:7690"]
+CMD ["--url", "http://0.0.0.0:7690/sovd"]

--- a/examples/server/simple/sampler.yaml
+++ b/examples/server/simple/sampler.yaml
@@ -1,5 +1,5 @@
 variables:
-  base_url: http://localhost:9000/sovd/v1/components/linux/data
+  base_url: http://localhost:7690/sovd/v1/components/linux/data
 
 runcharts:
   - title: CPU and Memory

--- a/opensovd-cli/gateway/README.md
+++ b/opensovd-cli/gateway/README.md
@@ -16,7 +16,7 @@ Exposes [OpenSOVD](https://github.com/eclipse-opensovd/opensovd-core) diagnostic
 opensovd-gateway
 
 # Listen on all interfaces
-opensovd-gateway --url 0.0.0.0:8080
+opensovd-gateway --url http://0.0.0.0:8080/sovd
 
 # Listen on a Unix socket
 opensovd-gateway --unix-socket /tmp/opensovd.sock
@@ -34,7 +34,7 @@ Mock data comes from the shared `opensovd-mocks` crate used across examples and 
 
 | Option          | Description                                          |
 |-----------------|------------------------------------------------------|
-| `--url`         | TCP address to listen on (default: `localhost:7690`) |
+| `--url`         | Server URL with base URI path (default: `http://localhost:7690/sovd`) |
 | `--unix-socket` | Unix socket path (`@` prefix for abstract sockets)   |
 | `--mock`        | Enable mock entities for testing                     |
 | `--serve-dir`   | Serve static files (`PATH:DIRECTORY`)                |

--- a/opensovd-cli/gateway/src/cli.rs
+++ b/opensovd-cli/gateway/src/cli.rs
@@ -43,7 +43,7 @@ pub struct Cli {
     /// The host:port is used for TCP binding (ignored when using --unix-socket
     /// or systemd socket activation). The path is used as the base URI for all
     /// API routes.
-    #[arg(long, default_value = DEFAULT_URL)]
+    #[arg(long, env = "SOVD_URL", default_value = DEFAULT_URL)]
     pub url: String,
 
     /// Path to a Unix socket to listen on. Use '@' prefix for abstract sockets.


### PR DESCRIPTION
## Summary

Three places in the repo carried stale port/URL values that didn't match the
gateway's current `--url` contract or the example server they paired with:

- `docker/Dockerfile` — `CMD ["--url", "0.0.0.0:7690"]`. Since #30, `--url`
  must be a full URL with scheme and base URI path; a bare `host:port`
  exits with `Error: invalid base URI`. The published image therefore
  refused to start with no extra args. Now `http://0.0.0.0:7690/sovd`.
- `opensovd-cli/gateway/README.md` — example used the same broken form,
  and the options table called `--url` a "TCP address" with default
  `localhost:7690`. Corrected to a full URL with default
  `http://localhost:7690/sovd`.
- `examples/server/simple/sampler.yaml` — fetched from `:9000`, but the
  example binds `:7690`. Pointed at the correct port.

Verified locally: `cargo run -p opensovd-gateway -- --url 0.0.0.0:7690`
exits with `invalid base URI`; with the fixed value it binds and serves.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions

## Related

Contract change introduced in #30; broken snippets imported in #34.