### PR TITLE
ci: enforce conventional commits on PR commits and titles

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,16 @@ jobs:
           fi
           echo "should_run=true" >> "$GITHUB_OUTPUT"
 
+  git-lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     needs: prepare
     if: needs.prepare.outputs.should_run == 'true'
@@ -425,7 +435,7 @@ jobs:
             artifacts/release/*
 
   gate:
-    needs: [prepare, build, licenses, advisories, lint, coverage, pages, docker, release]
+    needs: [prepare, git-lint, build, licenses, advisories, lint, coverage, pages, docker, release]
     if: always()
     runs-on: ubuntu-24.04
     permissions: {}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,6 +165,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-shared-key: ci
@@ -185,6 +187,24 @@ jobs:
             prek-${{ runner.os }}-
 
       - run: uv run prek run --all-files --show-diff-on-failure
+
+      - name: Validate commit subjects (Conventional Commits)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          fail=0
+          for sha in $(git rev-list "$BASE_SHA..$HEAD_SHA"); do
+            git log -1 --format=%B "$sha" > /tmp/commit-msg
+            if ! uv run prek run --hook-stage commit-msg \
+                --commit-msg-filename /tmp/commit-msg conventional-pre-commit; then
+              echo "::error::Non-conventional commit subject: $(git log -1 --format='%h %s' "$sha")"
+              fail=1
+            fi
+          done
+          exit "$fail"
 
   coverage:
     needs: prepare

--- a/.gitmessage
+++ b/.gitmessage
@@ -7,7 +7,7 @@
 #   |      |
 #   |      Scope: client|server|sovd
 #   |
-#   Type: feat|fix|doc|perf|refactor|style|test|ci|build|revert|chore
+#   Type: feat|fix|docs|perf|refactor|style|test|ci|build|revert|chore
 #
 # An optional footer may contain a GitHub Issue/PR.
 #
@@ -20,7 +20,7 @@
 #
 ### Example: Documentation change
 #
-# doc: add more rustdoc
+# docs: add more rustdoc
 #
 ### Example: Fix issue
 #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,12 @@ This project follows these conventions:
 
   * Reference the related issue in the footer
   * See git commit message [template](.gitmessage)
-* Run [prek](https://prek.j178.dev/) before submitting a PR
+* Run [prek](https://prek.j178.dev/) before submitting a PR. Install
+  the git hooks once so they run automatically on every commit:
+
+  ```bash
+  uv run prek install --hook-type pre-commit --hook-type commit-msg
+  ```
 
 ## Legal considerations
 


### PR DESCRIPTION
## Summary

 - `pr-lint` validates every commit subject in the PR range via the
   existing `conventional-pre-commit` hook, driven through `prek`.
 - New `git-lint` job validates the PR title
 - Document prek usage:  `prek install --hook-type pre-commit --hook-type commit-msg`.

 ## Checklist

 - [x] I have tested my changes locally
 - [x] I have added or updated documentation