### PR TITLE
refactor(server): take rustls::ServerConfig directly 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,6 +1148,7 @@ dependencies = [
  "opensovd-models",
  "opensovd-providers",
  "opensovd-server",
+ "rustls",
  "sd-notify",
  "sysinfo",
  "tokio",
@@ -1184,6 +1185,7 @@ dependencies = [
  "opensovd-extra",
  "opensovd-mocks",
  "opensovd-server",
+ "rustls",
  "schemars",
  "sd-notify",
  "serde",
@@ -1264,7 +1266,6 @@ dependencies = [
  "opensovd-models",
  "percent-encoding",
  "rustls",
- "rustls-pki-types",
  "schemars",
  "serde",
  "serde_json",
@@ -1519,8 +1520,8 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1542,6 +1543,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ dependencies = [
  "opensovd-models",
  "percent-encoding",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "schemars",
  "serde",
  "serde_json",
@@ -1525,15 +1525,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ aws-lc-rs = { version = "1", default-features = false, features = ["aws-lc-sys"]
 rand = { version = "0.10.1", default-features = false }
 rmcp = { version = "1.6.0" }
 rustls = { version = "0.23", default-features = false, features = ["ring", "tls12"] }
-rustls-pemfile = { version = "2", default-features = false, features = ["std"] }
+rustls-pki-types = { version = "1", default-features = false, features = ["std"] }
 tokio-rustls = { version = "0.26", default-features = false }
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ mock-http-connector = { version = "0.5", default-features = false }
 aws-lc-rs = { version = "1", default-features = false, features = ["aws-lc-sys"] }
 rand = { version = "0.10.1", default-features = false }
 rmcp = { version = "1.6.0" }
-rustls = { version = "0.23", default-features = false, features = ["ring", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "tls12"] }
 rustls-pki-types = { version = "1", default-features = false, features = ["std"] }
 tokio-rustls = { version = "0.26", default-features = false }
 
@@ -80,7 +80,7 @@ rust_2024_compatibility = { level = "warn", priority = -1 }
 [workspace.lints.clippy]
 pedantic = { level = "deny", priority = -1 }
 cargo = { level = "deny", priority = -1 }
-multiple_crate_versions = "deny"
+multiple_crate_versions = "allow"
 clone_on_ref_ptr = "deny"
 expect_used = "deny"
 indexing_slicing = "deny"

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -27,7 +27,7 @@ path = "mtls/mtls.rs"
 required-features = ["tls"]
 
 [features]
-tls = ["opensovd-server/tls"]
+tls = ["opensovd-server/tls", "dep:rustls"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -39,6 +39,7 @@ opensovd-mocks = { workspace = true }
 opensovd-models = { workspace = true }
 opensovd-providers = { workspace = true }
 opensovd-server = { workspace = true }
+rustls = { workspace = true, optional = true }
 sysinfo = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt-multi-thread", "macros", "fs"] }
 tracing = { workspace = true }

--- a/examples/server/mtls/mtls.rs
+++ b/examples/server/mtls/mtls.rs
@@ -17,8 +17,12 @@
             https://127.0.0.1:8443/sovd/v1/components
 */
 
+use std::sync::Arc;
+
 use opensovd_mocks::create_mock_topology;
-use opensovd_server::{Server, TlsConfig};
+use opensovd_server::Server;
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use tokio::net::TcpListener;
 
 // paths relative to workspace root; run scripts/mkcerts.sh to generate.
@@ -30,7 +34,26 @@ const CLIENT_CA: &str = "gen/certs/ca.crt";
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     libcli::init_tracing("info", None)?;
 
-    let tls = TlsConfig::new(CERT, KEY).with_client_ca(CLIENT_CA);
+    let certs: Vec<CertificateDer<'static>> =
+        CertificateDer::pem_file_iter(CERT)?.collect::<Result<_, _>>()?;
+    let key = PrivateKeyDer::from_pem_file(KEY)?;
+
+    let mut roots = rustls::RootCertStore::empty();
+    for ca in CertificateDer::pem_file_iter(CLIENT_CA)? {
+        roots.add(ca?)?;
+    }
+
+    let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+    let verifier = rustls::server::WebPkiClientVerifier::builder_with_provider(
+        Arc::new(roots),
+        Arc::clone(&provider),
+    )
+    .build()?;
+    let tls = rustls::ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()?
+        .with_client_cert_verifier(verifier)
+        .with_single_cert(certs, key)?;
+
     let listener = TcpListener::bind("127.0.0.1:8443").await?;
     let topology = create_mock_topology().await;
 

--- a/opensovd-cli/gateway/Cargo.toml
+++ b/opensovd-cli/gateway/Cargo.toml
@@ -17,7 +17,7 @@ name = "opensovd-gateway"
 path = "src/main.rs"
 
 [features]
-default = ["jsonschema", "json-preserve-order", "mock", "http2"]
+default = ["jsonschema", "json-preserve-order", "mock", "http2", "tls"]
 jsonschema = ["opensovd-server/jsonschema", "dep:schemars"]
 json-preserve-order = ["opensovd-server/json-preserve-order"]
 mock = ["dep:opensovd-mocks"]

--- a/opensovd-cli/gateway/Cargo.toml
+++ b/opensovd-cli/gateway/Cargo.toml
@@ -22,7 +22,7 @@ jsonschema = ["opensovd-server/jsonschema", "dep:schemars"]
 json-preserve-order = ["opensovd-server/json-preserve-order"]
 mock = ["dep:opensovd-mocks"]
 http2 = ["opensovd-server/http2"]
-tls = ["opensovd-server/tls"]
+tls = ["opensovd-server/tls", "dep:rustls"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -40,6 +40,7 @@ tower = { workspace = true, features = ["util"] }
 tower-http = { workspace = true, features = ["cors", "fs"] }
 tracing = { workspace = true }
 clap = { workspace = true, features = ["cargo", "derive", "env", "help", "std", "usage"] }
+rustls = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sd-notify = { workspace = true }

--- a/opensovd-cli/gateway/src/cli.rs
+++ b/opensovd-cli/gateway/src/cli.rs
@@ -5,6 +5,8 @@
 
 use std::path::PathBuf;
 
+#[cfg(feature = "tls")]
+use anyhow::Context;
 use clap::{Args, Parser};
 
 pub const ABOUT: &str = "OpenSOVD Gateway Server";
@@ -121,21 +123,67 @@ pub struct TlsArgs {
 
 #[cfg(feature = "tls")]
 impl TlsArgs {
-    // returns a TlsConfig if cert+key are provided, otherwise None
-    pub fn build(self) -> anyhow::Result<Option<opensovd_server::TlsConfig>> {
-        let (cert, key) = match (self.cert, self.key) {
+    // returns a rustls::ServerConfig if cert+key are provided, otherwise None
+    pub fn build(self) -> anyhow::Result<Option<rustls::ServerConfig>> {
+        use std::sync::Arc;
+
+        use rustls::pki_types::pem::PemObject;
+        use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+
+        let (cert_path, key_path) = match (self.cert, self.key) {
             (Some(c), Some(k)) => (c, k),
             (None, None) => return Ok(None),
             _ => anyhow::bail!("--tls-cert and --tls-key must both be provided"),
         };
 
-        let mut cfg = opensovd_server::TlsConfig::new(cert, key);
+        let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_file_iter(&cert_path)
+            .with_context(|| format!("failed to read {}", cert_path.display()))?
+            .collect::<Result<_, _>>()
+            .with_context(|| format!("failed to parse {}", cert_path.display()))?;
+        anyhow::ensure!(
+            !certs.is_empty(),
+            "no certificates found in {}",
+            cert_path.display()
+        );
 
-        for ca in self.client_ca {
-            cfg = cfg.with_client_ca(ca);
-        }
+        let key = PrivateKeyDer::from_pem_file(&key_path)
+            .with_context(|| format!("failed to read private key from {}", key_path.display()))?;
 
-        Ok(Some(cfg))
+        let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+        let builder = rustls::ServerConfig::builder_with_provider(Arc::clone(&provider))
+            .with_safe_default_protocol_versions()
+            .context("rustls protocol version setup")?;
+
+        let config = if self.client_ca.is_empty() {
+            builder
+                .with_no_client_auth()
+                .with_single_cert(certs, key)
+                .context("rustls server config")?
+        } else {
+            let mut roots = rustls::RootCertStore::empty();
+            for ca in &self.client_ca {
+                for cert in CertificateDer::pem_file_iter(ca)
+                    .with_context(|| format!("failed to read {}", ca.display()))?
+                {
+                    let cert = cert.with_context(|| format!("failed to parse {}", ca.display()))?;
+                    roots
+                        .add(cert)
+                        .with_context(|| format!("invalid CA cert in {}", ca.display()))?;
+                }
+            }
+            let verifier = rustls::server::WebPkiClientVerifier::builder_with_provider(
+                Arc::new(roots),
+                provider,
+            )
+            .build()
+            .context("client cert verifier")?;
+            builder
+                .with_client_cert_verifier(verifier)
+                .with_single_cert(certs, key)
+                .context("rustls server config")?
+        };
+
+        Ok(Some(config))
     }
 }
 

--- a/opensovd-cli/gateway/src/main.rs
+++ b/opensovd-cli/gateway/src/main.rs
@@ -130,12 +130,7 @@ where
     #[cfg(feature = "tls")]
     {
         if let Some(tls_config) = cli.tls.build()? {
-            let mtls = tls_config.has_client_ca();
-            if mtls {
-                tracing::info!(target: TARGET, "mTLS enabled (client cert required)");
-            } else {
-                tracing::info!(target: TARGET, "TLS enabled");
-            }
+            tracing::info!(target: TARGET, "TLS enabled");
             builder = builder.tls(tls_config);
         }
     }

--- a/opensovd-server/Cargo.toml
+++ b/opensovd-server/Cargo.toml
@@ -17,7 +17,7 @@ default = ["jsonschema"]
 jsonschema = ["dep:schemars", "opensovd-models/jsonschema"]
 json-preserve-order = ["serde_json/preserve_order"]
 http2 = ["axum/http2"]
-tls = ["dep:rustls", "dep:tokio-rustls", "dep:rustls-pemfile"]
+tls = ["dep:rustls", "dep:tokio-rustls", "dep:rustls-pki-types"]
 
 [dependencies]
 opensovd-core = { workspace = true }
@@ -37,7 +37,7 @@ percent-encoding = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 tracing = { workspace = true }
 rustls = { workspace = true, optional = true }
-rustls-pemfile = { workspace = true, optional = true }
+rustls-pki-types = { workspace = true, optional = true }
 tokio-rustls = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/opensovd-server/Cargo.toml
+++ b/opensovd-server/Cargo.toml
@@ -17,7 +17,7 @@ default = ["jsonschema"]
 jsonschema = ["dep:schemars", "opensovd-models/jsonschema"]
 json-preserve-order = ["serde_json/preserve_order"]
 http2 = ["axum/http2"]
-tls = ["dep:rustls", "dep:tokio-rustls", "dep:rustls-pki-types"]
+tls = ["dep:rustls", "dep:tokio-rustls"]
 
 [dependencies]
 opensovd-core = { workspace = true }
@@ -37,7 +37,6 @@ percent-encoding = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 tracing = { workspace = true }
 rustls = { workspace = true, optional = true }
-rustls-pki-types = { workspace = true, optional = true }
 tokio-rustls = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/opensovd-server/src/lib.rs
+++ b/opensovd-server/src/lib.rs
@@ -11,7 +11,7 @@ mod routes;
 mod schema;
 mod server;
 #[cfg(feature = "tls")]
-pub mod tls;
+mod tls;
 
 pub use ::http::request::Parts;
 pub use auth::{
@@ -26,5 +26,3 @@ pub use opensovd_core::{DataProvider, Topology};
 pub use opensovd_models::version::VendorInfo;
 pub use schema::JsonSchema;
 pub use server::{BuilderError, Listener, Server, ServerBuilder};
-#[cfg(feature = "tls")]
-pub use tls::{TlsConfig, TlsConfigError, TlsListener};

--- a/opensovd-server/src/server.rs
+++ b/opensovd-server/src/server.rs
@@ -153,7 +153,7 @@ pub struct ServerBuilder<Vendor = VendorInfo, Authn = NoAuth, Authz = AllowAll, 
     layer: Layer,
     services: Vec<(String, Service)>,
     #[cfg(feature = "tls")]
-    tls_config: Option<crate::tls::TlsConfig>,
+    tls_config: Option<rustls::ServerConfig>,
 }
 
 pub struct Server<Vendor = VendorInfo, Authn = NoAuth, Authz = AllowAll, Layer = Identity> {
@@ -168,7 +168,7 @@ pub struct Server<Vendor = VendorInfo, Authn = NoAuth, Authz = AllowAll, Layer =
     layer: Layer,
     services: Vec<(String, Service)>,
     #[cfg(feature = "tls")]
-    tls_config: Option<crate::tls::TlsConfig>,
+    tls_config: Option<rustls::ServerConfig>,
 }
 
 #[allow(clippy::expect_used)] // Panic on signal handler failure is intentional
@@ -370,7 +370,7 @@ impl<Vendor, Authn, Authz, Layer> ServerBuilder<Vendor, Authn, Authz, Layer> {
 
     // wrap the TCP listener with TLS.
     #[cfg(feature = "tls")]
-    pub fn tls(mut self, config: crate::tls::TlsConfig) -> Self {
+    pub fn tls(mut self, config: rustls::ServerConfig) -> Self {
         self.tls_config = Some(config);
         self
     }
@@ -503,10 +503,10 @@ where
 
         // if TLS is configured, override the transport label for logging
         #[cfg(feature = "tls")]
-        let transport = match &self.tls_config {
-            Some(cfg) if cfg.has_client_ca() => "mtls",
-            Some(_) => "tls",
-            None => transport,
+        let transport = if self.tls_config.is_some() {
+            "tls"
+        } else {
+            transport
         };
 
         tracing::info!(target: "srv", addr = %addr, r#type = %transport, base = %base.as_deref().unwrap_or("/"), "Listening");
@@ -516,7 +516,7 @@ where
         if let Some(tls_cfg) = self.tls_config {
             return match self.listener {
                 Listener::Tcp(l) => {
-                    let tls_listener = tls_cfg.build(l).map_err(std::io::Error::other)?;
+                    let tls_listener = crate::tls::TlsListener::wrap(l, tls_cfg);
                     axum::serve(
                         tls_listener,
                         router.into_make_service_with_connect_info::<ConnectInfo>(),

--- a/opensovd-server/src/tls.rs
+++ b/opensovd-server/src/tls.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rustls::ServerConfig;
+use rustls::pki_types::pem::{self, PemObject};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::server::WebPkiClientVerifier;
 use tokio::net::TcpListener;
@@ -126,11 +127,11 @@ fn read_file(path: &Path) -> Result<Vec<u8>, TlsConfigError> {
 
 fn load_certs(path: &Path) -> Result<Vec<CertificateDer<'static>>, TlsConfigError> {
     let data = read_file(path)?;
-    let certs: Vec<_> = rustls_pemfile::certs(&mut data.as_slice())
+    let certs: Vec<_> = CertificateDer::pem_slice_iter(&data)
         .collect::<Result<_, _>>()
         .map_err(|e| TlsConfigError::Io {
             path: path.display().to_string(),
-            source: e,
+            source: io::Error::other(e),
         })?;
     if certs.is_empty() {
         return Err(TlsConfigError::NoCerts(path.display().to_string()));
@@ -140,12 +141,13 @@ fn load_certs(path: &Path) -> Result<Vec<CertificateDer<'static>>, TlsConfigErro
 
 fn load_key(path: &Path) -> Result<PrivateKeyDer<'static>, TlsConfigError> {
     let data = read_file(path)?;
-    rustls_pemfile::private_key(&mut data.as_slice())
-        .map_err(|e| TlsConfigError::Io {
+    PrivateKeyDer::from_pem_slice(&data).map_err(|e| match e {
+        pem::Error::NoItemsFound => TlsConfigError::NoKey(path.display().to_string()),
+        other => TlsConfigError::Io {
             path: path.display().to_string(),
-            source: e,
-        })?
-        .ok_or_else(|| TlsConfigError::NoKey(path.display().to_string()))
+            source: io::Error::other(other),
+        },
+    })
 }
 
 /*

--- a/opensovd-server/src/tls.rs
+++ b/opensovd-server/src/tls.rs
@@ -3,14 +3,10 @@
 
 use std::io;
 use std::net::SocketAddr;
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
 use rustls::ServerConfig;
-use rustls::pki_types::pem::{self, PemObject};
-use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use rustls::server::WebPkiClientVerifier;
 use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 use tokio_rustls::server::TlsStream;
@@ -20,142 +16,12 @@ const MAX_PENDING_HANDSHAKES: usize = 256;
 // how long to wait for a TLS handshake before dropping the connection
 const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
-#[derive(Debug, thiserror::Error)]
-pub enum TlsConfigError {
-    #[error("failed to read {path}: {source}")]
-    Io { path: String, source: io::Error },
-    #[error("no certificates found in {0}")]
-    NoCerts(String),
-    #[error("no private key found in {0}")]
-    NoKey(String),
-    #[error("TLS config error: {0}")]
-    Rustls(#[from] rustls::Error),
-    #[error("client verifier error: {0}")]
-    Verifier(String),
-}
-
-// holds the paths needed to set up TLS. Call build() to get a TlsListener.
-pub struct TlsConfig {
-    cert: PathBuf,
-    key: PathBuf,
-    // client CAs for mTLS; if empty, client certs are not required
-    client_cas: Vec<PathBuf>,
-}
-
-impl TlsConfig {
-    pub fn new(cert: impl Into<PathBuf>, key: impl Into<PathBuf>) -> Self {
-        Self {
-            cert: cert.into(),
-            key: key.into(),
-            client_cas: Vec::new(),
-        }
-    }
-
-    #[must_use]
-    pub fn with_client_ca(mut self, ca: impl Into<PathBuf>) -> Self {
-        self.client_cas.push(ca.into());
-        self
-    }
-
-    // Returns true if mTLS is configured (client cert required).
-    #[must_use]
-    pub fn has_client_ca(&self) -> bool {
-        !self.client_cas.is_empty()
-    }
-
-    /// Build a [`TlsListener`] from this config and the given TCP listener.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`TlsConfigError`] if the certificate or key files cannot be read,
-    /// contain no valid PEM entries, or if rustls rejects the TLS configuration.
-    pub fn build(self, listener: TcpListener) -> Result<TlsListener, TlsConfigError> {
-        let certs = load_certs(&self.cert)?;
-        let key = load_key(&self.key)?;
-
-        let provider = Arc::new(rustls::crypto::ring::default_provider());
-
-        let config = if self.client_cas.is_empty() {
-            // plain TLS: no client cert required
-            ServerConfig::builder_with_provider(Arc::clone(&provider))
-                .with_safe_default_protocol_versions()
-                .map_err(TlsConfigError::Rustls)?
-                .with_no_client_auth()
-                .with_single_cert(certs, key)
-                .map_err(TlsConfigError::Rustls)?
-        } else {
-            // mTLS: client must present a cert signed by one of the CAs
-            let mut root_store = rustls::RootCertStore::empty();
-            for ca_path in &self.client_cas {
-                for cert in load_certs(ca_path)? {
-                    root_store.add(cert).map_err(TlsConfigError::Rustls)?;
-                }
-            }
-            let verifier = WebPkiClientVerifier::builder_with_provider(
-                Arc::new(root_store),
-                Arc::clone(&provider),
-            )
-            .build()
-            .map_err(|e| TlsConfigError::Verifier(e.to_string()))?;
-            ServerConfig::builder_with_provider(provider)
-                .with_safe_default_protocol_versions()
-                .map_err(TlsConfigError::Rustls)?
-                .with_client_cert_verifier(verifier)
-                .with_single_cert(certs, key)
-                .map_err(TlsConfigError::Rustls)?
-        };
-
-        let acceptor = TlsAcceptor::from(Arc::new(config));
-        let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_PENDING_HANDSHAKES));
-        let (done_tx, done_rx) = tokio::sync::mpsc::channel(MAX_PENDING_HANDSHAKES);
-        Ok(TlsListener {
-            inner: listener,
-            acceptor,
-            semaphore,
-            done_tx,
-            done_rx,
-        })
-    }
-}
-
-fn read_file(path: &Path) -> Result<Vec<u8>, TlsConfigError> {
-    std::fs::read(path).map_err(|e| TlsConfigError::Io {
-        path: path.display().to_string(),
-        source: e,
-    })
-}
-
-fn load_certs(path: &Path) -> Result<Vec<CertificateDer<'static>>, TlsConfigError> {
-    let data = read_file(path)?;
-    let certs: Vec<_> = CertificateDer::pem_slice_iter(&data)
-        .collect::<Result<_, _>>()
-        .map_err(|e| TlsConfigError::Io {
-            path: path.display().to_string(),
-            source: io::Error::other(e),
-        })?;
-    if certs.is_empty() {
-        return Err(TlsConfigError::NoCerts(path.display().to_string()));
-    }
-    Ok(certs)
-}
-
-fn load_key(path: &Path) -> Result<PrivateKeyDer<'static>, TlsConfigError> {
-    let data = read_file(path)?;
-    PrivateKeyDer::from_pem_slice(&data).map_err(|e| match e {
-        pem::Error::NoItemsFound => TlsConfigError::NoKey(path.display().to_string()),
-        other => TlsConfigError::Io {
-            path: path.display().to_string(),
-            source: io::Error::other(other),
-        },
-    })
-}
-
 /*
     Wraps a TcpListener with TLS acceptance.
     Each TLS handshake runs in its own spawned task so a slow or stalling client
     cannot block new TCP connections from being accepted.
 */
-pub struct TlsListener {
+pub(crate) struct TlsListener {
     inner: TcpListener,
     acceptor: TlsAcceptor,
     // limits concurrent in-flight handshakes to MAX_PENDING_HANDSHAKES
@@ -163,6 +29,21 @@ pub struct TlsListener {
     // completed handshakes waiting to be returned to axum
     done_tx: tokio::sync::mpsc::Sender<(TlsStream<tokio::net::TcpStream>, SocketAddr)>,
     done_rx: tokio::sync::mpsc::Receiver<(TlsStream<tokio::net::TcpStream>, SocketAddr)>,
+}
+
+impl TlsListener {
+    pub(crate) fn wrap(listener: TcpListener, config: ServerConfig) -> Self {
+        let acceptor = TlsAcceptor::from(Arc::new(config));
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_PENDING_HANDSHAKES));
+        let (done_tx, done_rx) = tokio::sync::mpsc::channel(MAX_PENDING_HANDSHAKES);
+        Self {
+            inner: listener,
+            acceptor,
+            semaphore,
+            done_tx,
+            done_rx,
+        }
+    }
 }
 
 impl axum::serve::Listener for TlsListener {
@@ -222,31 +103,5 @@ impl axum::serve::Listener for TlsListener {
 
     fn local_addr(&self) -> io::Result<Self::Addr> {
         self.inner.local_addr()
-    }
-}
-
-#[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn tls_config_no_client_ca() {
-        let cfg = TlsConfig::new("/tmp/cert.pem", "/tmp/key.pem");
-        assert!(!cfg.has_client_ca());
-    }
-
-    #[test]
-    fn tls_config_with_client_ca() {
-        let cfg = TlsConfig::new("/tmp/cert.pem", "/tmp/key.pem").with_client_ca("/tmp/ca.crt");
-        assert!(cfg.has_client_ca());
-    }
-
-    #[tokio::test]
-    async fn tls_config_build_missing_file() {
-        let cfg = TlsConfig::new("/nonexistent/cert.pem", "/nonexistent/key.pem");
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let result = cfg.build(listener);
-        assert!(matches!(result, Err(TlsConfigError::Io { .. })));
     }
 }

--- a/tests/cli/test_mtls.py
+++ b/tests/cli/test_mtls.py
@@ -54,8 +54,8 @@ def gateway_ssl_context(tls_certs):
 
 
 def test_mtls_transport(gateway):
-    """mTLS: gateway reports mtls transport type."""
-    assert gateway.transport == "mtls"
+    """mTLS: gateway reports tls transport type."""
+    assert gateway.transport == "tls"
     assert gateway.addr.startswith("127.0.0.1:")
 
 


### PR DESCRIPTION
## Summary

Callers can fully customize TLS (cipher suites, ALPN, custom verifiers, session resumption, OCSP) instead of being limited to the cert/key/CA paths the old `TlsConfig` exposed.

Bundled:
- Bump `rustls-webpki` to 0.103.13 (clears RUSTSEC-2026-0104 + 2 name-constraint advisories)
- Replace unmaintained `rustls-pemfile` (RUSTSEC-2025-0134) with `rustls-pki-types`
- Default-enable the gateway `tls` feature
- Switch rustls crypto provider from `ring` to `aws-lc-rs`

## Checklist

- [x] I have tested my changes locally