### PR TITLE
chore(deps): bump rmcp to 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.16.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
 dependencies = [
  "async-trait",
  "base64",
@@ -1502,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.16.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ tracing-subscriber = { version = "0.3", default-features = false }
 mock-http-connector = { version = "0.5", default-features = false }
 aws-lc-rs = { version = "1", default-features = false, features = ["aws-lc-sys"] }
 rand = { version = "0.10.1", default-features = false }
-rmcp = { version = "0.16.0" }
+rmcp = { version = "1.6.0" }
 rustls = { version = "0.23", default-features = false, features = ["ring", "tls12"] }
 rustls-pemfile = { version = "2", default-features = false, features = ["std"] }
 tokio-rustls = { version = "0.26", default-features = false }

--- a/opensovd-cli/mcp/src/main.rs
+++ b/opensovd-cli/mcp/src/main.rs
@@ -96,49 +96,39 @@ impl McpServer {
         description = "Explore the vehicle diagnostic topology by listing components, areas, and apps."
     )]
     async fn explore_topology(&self) -> GetPromptResult {
-        GetPromptResult {
-            description: Some(
-                "Explore the vehicle diagnostic topology exposed by the SOVD server.".into(),
-            ),
-            messages: vec![PromptMessage::new_text(
-                PromptMessageRole::User,
-                "Read the sovd://topology resource, then:\n\
-                     1. List components\n\
-                     2. List areas\n\
-                     3. List apps and their hosting relationships\n\
-                     4. Summarize the vehicle's diagnostic topology",
-            )],
-        }
+        GetPromptResult::new(vec![PromptMessage::new_text(
+            PromptMessageRole::User,
+            "Read the sovd://topology resource, then:\n\
+                 1. List components\n\
+                 2. List areas\n\
+                 3. List apps and their hosting relationships\n\
+                 4. Summarize the vehicle's diagnostic topology",
+        )])
+        .with_description("Explore the vehicle diagnostic topology exposed by the SOVD server.")
     }
 }
 
-#[tool_handler]
-#[prompt_handler]
+#[tool_handler(router = self.tool_router)]
+#[prompt_handler(router = self.prompt_router)]
 impl ServerHandler for McpServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            server_info: Implementation {
-                name: "opensovd-mcp".into(),
-                version: env!("CARGO_PKG_VERSION").into(),
-                description: Some(env!("CARGO_PKG_DESCRIPTION").into()),
-                ..Default::default()
-            },
-            instructions: Some(
+        let capabilities = ServerCapabilities::builder()
+            .enable_tools()
+            .enable_resources()
+            .enable_prompts()
+            .build();
+        let server_info = Implementation::new("opensovd-mcp", env!("CARGO_PKG_VERSION"))
+            .with_description(env!("CARGO_PKG_DESCRIPTION"));
+        ServerInfo::new(capabilities)
+            .with_server_info(server_info)
+            .with_instructions(
                 "OpenSOVD MCP server for vehicle diagnostics. \
                  Base URI: /sovd/v1. \
                  Entity hierarchy: Areas > Components > Apps > Functions. \
                  Each entity may expose: data, faults, operations, configurations, \
                  bulk-data, locks, and modes. \
-                 Use the topology resource to explore the vehicle."
-                    .into(),
-            ),
-            capabilities: ServerCapabilities::builder()
-                .enable_tools()
-                .enable_resources()
-                .enable_prompts()
-                .build(),
-            ..Default::default()
-        }
+                 Use the topology resource to explore the vehicle.",
+            )
     }
 
     async fn list_resources(
@@ -233,9 +223,10 @@ impl ServerHandler for McpServer {
             let _ = writeln!(text, "- {name} (id: {id})", name = app.name, id = app.id);
         }
 
-        Ok(ReadResourceResult {
-            contents: vec![ResourceContents::text(text, TOPOLOGY_URI)],
-        })
+        Ok(ReadResourceResult::new(vec![ResourceContents::text(
+            text,
+            TOPOLOGY_URI,
+        )]))
     }
 }
 
@@ -370,10 +361,7 @@ mod tests {
         let client = setup(mock_client(builder.build())).await;
 
         let result = client
-            .read_resource(ReadResourceRequestParams {
-                meta: None,
-                uri: TOPOLOGY_URI.into(),
-            })
+            .read_resource(ReadResourceRequestParams::new(TOPOLOGY_URI))
             .await?;
 
         let text = match &result.contents[0] {
@@ -415,11 +403,7 @@ mod tests {
         let client = setup(mock_client(connector)).await;
 
         let result = client
-            .get_prompt(GetPromptRequestParams {
-                meta: None,
-                name: "explore-topology".into(),
-                arguments: None,
-            })
+            .get_prompt(GetPromptRequestParams::new("explore-topology"))
             .await?;
 
         assert!(!result.messages.is_empty(), "expected at least one message");
@@ -454,12 +438,7 @@ mod tests {
         let client = setup(mock_client(builder.build())).await;
 
         let result = client
-            .call_tool(CallToolRequestParams {
-                meta: None,
-                name: "list_components".into(),
-                arguments: None,
-                task: None,
-            })
+            .call_tool(CallToolRequestParams::new("list_components"))
             .await?;
 
         let structured = result
@@ -488,12 +467,7 @@ mod tests {
         let client = setup(mock_client(builder.build())).await;
 
         let result = client
-            .call_tool(CallToolRequestParams {
-                meta: None,
-                name: "list_areas".into(),
-                arguments: None,
-                task: None,
-            })
+            .call_tool(CallToolRequestParams::new("list_areas"))
             .await?;
 
         let structured = result
@@ -522,12 +496,7 @@ mod tests {
         let client = setup(mock_client(builder.build())).await;
 
         let result = client
-            .call_tool(CallToolRequestParams {
-                meta: None,
-                name: "list_apps".into(),
-                arguments: None,
-                task: None,
-            })
+            .call_tool(CallToolRequestParams::new("list_apps"))
             .await?;
 
         let structured = result


### PR DESCRIPTION
## Summary
Bump rmcp 0.16 -> 1.6 and port opensovd-mcp to the new builder APIs (model structs are now `#[non_exhaustive]`); wire the handler macros to the cached `tool_router` / `prompt_router` fields via `router = self.…` so they aren't reconstructed per request.

## Checklist
- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
Supersedes the rmcp portion of dependabot PR #54.