### PR TITLE
chore(deps): bump sd-notify to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "sd-notify"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b943eadf71d8b69e661330cb0e2656e31040acf21ee7708e2c238a0ec6af2bf4"
+checksum = "3e4ef7359e694bfaf1dd27a30f9d760b54c00dfae9f19bd0c05a39bc9128fe76"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ pin-project = { version = "1", default-features = false }
 regorus = { version = "0.9", default-features = false, features = ["arc", "glob"] }
 schemars = { version = "1", default-features = false }
 sysinfo = { version = "0.38", default-features = false, features = ["system"] }
-sd-notify = { version = "0.4", default-features = false }
+sd-notify = { version = "0.5", default-features = false }
 serde = { version = "1", default-features = false }
 serde_json = { version = "1", default-features = false }
 thiserror = { version = "2", default-features = false }

--- a/examples/server/systemd/systemd.rs
+++ b/examples/server/systemd/systemd.rs
@@ -43,7 +43,7 @@ mod systemd {
             .layer(libcli::trace::trace_layer())
             .build()?;
 
-        sd_notify::notify(false, &[NotifyState::Ready])?;
+        sd_notify::notify(&[NotifyState::Ready])?;
         tracing::info!(addr = %addr, "Server running");
         server.serve().await?;
         Ok(())

--- a/opensovd-cli/gateway/src/main.rs
+++ b/opensovd-cli/gateway/src/main.rs
@@ -251,7 +251,7 @@ async fn configure_topology<Vendor, Authn, Authz, Layer>(
 
 fn notify_readiness() {
     #[cfg(target_os = "linux")]
-    if let Err(e) = sd_notify::notify(false, &[sd_notify::NotifyState::Ready]) {
+    if let Err(e) = sd_notify::notify(&[sd_notify::NotifyState::Ready]) {
         tracing::warn!(target: TARGET, error = %e, "Failed to notify systemd readiness");
     }
 }


### PR DESCRIPTION
## Summary

`sd-notify` 0.5 dropped the `unset_env: bool` parameter from `notify`
(now `notify(&[NotifyState])`). Bump the workspace dep from 0.4 to 0.5
and update the two call sites:
`opensovd-cli/gateway/src/main.rs` and
`examples/server/systemd/systemd.rs`.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related

Unblocks #57 (cargo group bump).

