### PR TITLE
ci(deps): track docker and pre-commit in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,3 +46,14 @@ updates:
           - "*"
     commit-message:
       prefix: "chore(deps)"
+
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      pre-commit:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,14 @@ updates:
           - "*"
     commit-message:
       prefix: "chore(deps)"
+
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: monthly
+    groups:
+      docker:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Summary
Extend Dependabot to two more ecosystems, same monthly grouped pattern.

- `docker` for `/docker/Dockerfile`
- `pre-commit` for `.pre-commit-config.yaml`

## Checklist
- [x] I have tested my changes locally
