### PR TITLE
chore(pre-commit): tighten hooks and drop docker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
 # SPDX-License-Identifier: Apache-2.0
 
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: check-toml
+      - id: check-json
       - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -15,13 +18,20 @@ repos:
     rev: v0.21.0
     hooks:
       - id: yamlfmt
-  - repo: https://github.com/doublify/pre-commit-rust
-    rev: v1.0
+  - repo: local
     hooks:
-      - id: fmt
-        args: ['--all', '--']
-      - id: clippy
-        args: ['--all-targets', '--all-features', '--', '-D', 'warnings', '-A', 'clippy::doc_markdown']
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings -A clippy::doc_markdown
+        language: system
+        types: [rust]
+        pass_filenames: false
   - repo: https://github.com/bnjbvr/cargo-machete
     rev: v0.9.2
     hooks:
@@ -39,7 +49,7 @@ repos:
     hooks:
       - id: ty
         name: ty check
-        entry: uv run --with ty -- ty check
+        entry: uv run --locked --group tools -- ty check
         language: system
         types: [python]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.48.0
     hooks:
-      - id: markdownlint-docker
+      - id: markdownlint
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12
     hooks:


### PR DESCRIPTION
## Summary

`--locked` ties hooks to the workspace's pinned toolchain/lockfiles, eliminating drift between local pre-commit and CI. Dockerless hooks remove the docker daemon as a contributor prerequisite.

- `markdownlint-docker` replaced by `markdownlint`
- `doublify/pre-commit-rust` replaced by local `cargo fmt`/`cargo clippy` with `--locked`
- `ty` pinned to `uv run --locked --group tools`
- adds `check-json` and installs `commit-msg` hooks by default

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

