### PR TITLE
feat(ci): include e2e tests in coverage measurement

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -229,6 +229,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -237,15 +238,46 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov@${{ env.CARGO_LLVM_COV_VERSION }}
+      - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - run: npm install -g @usebruno/cli
 
-      - run: cargo llvm-cov test --locked --all-features --html
-      - run: cargo llvm-cov report --json --output-path coverage.json
+      # --opensovd-coverage sets up cargo-llvm-cov instrumentation and writes the
+      # merged report (coverage.json + HTML + Cobertura). test_rust.py runs the
+      # Rust unit/integration/doc tests (--all-features) and the e2e tests spawn
+      # the gateway, which inherits LLVM_PROFILE_FILE, so all of it is one report.
+      - name: Collect coverage (Rust + e2e)
+        run: uv run pytest tests/ --opensovd-coverage
 
       - id: cov
         run: |
           PERCENT=$(jq -r '.data[0].totals.lines.percent | floor' coverage.json)
           COLOR=$([[ $PERCENT -ge 80 ]] && echo 28A745 || ([[ $PERCENT -ge 60 ]] && echo B08800 || echo CB2431))
           curl -s "https://img.shields.io/badge/coverage-${PERCENT}%25-${COLOR}" -o target/llvm-cov/html/badge.svg
+          bash scripts/coverage-report.sh coverage.json > coverage-comment.md
+          bash scripts/coverage-report.sh --detail coverage.json >> "$GITHUB_STEP_SUMMARY"
+
+      # Post or update a sticky PR comment, identified by the marker on line 1
+      # of the rendered body. Restricted to same-repo PRs since the token is
+      # read-only for forks.
+      - name: Comment coverage on PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          jq -Rs '{body: .}' coverage-comment.md > comment.json
+          marker='<!-- coverage-report -->'
+          id=$(gh api --paginate "repos/${REPO}/issues/${PR}/comments" \
+            -q ".[] | select(.body | startswith(\"${marker}\")) | .id" | head -n1)
+          if [ -n "$id" ]; then
+            gh api --method PATCH "repos/${REPO}/issues/comments/${id}" --input comment.json >/dev/null
+          else
+            gh api --method POST "repos/${REPO}/issues/${PR}/comments" --input comment.json >/dev/null
+          fi
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+coverage.json
 dist/
 __pycache__/
 *.pyc

--- a/scripts/coverage-report.sh
+++ b/scripts/coverage-report.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Render a Markdown coverage report from a cargo-llvm-cov JSON report.
+#
+# Usage (run from anywhere):
+#   bash scripts/coverage-report.sh [--detail] [JSON] [WORKSPACE_ROOT]
+#
+#   --detail   also append a full per-file table sorted by path
+
+set -euo pipefail
+
+mode=summary
+case "${1:-}" in
+  --detail) mode=detail; shift ;;
+  --*)
+    echo "unknown option: $1" >&2
+    exit 2
+    ;;
+esac
+
+json="${1:-coverage.json}"
+root="${2:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+root="${root%/}/"
+
+total=$(jq -r '.data[0].totals.lines.percent' "$json")
+covered=$(jq -r '.data[0].totals.lines.covered' "$json")
+count=$(jq -r '.data[0].totals.lines.count' "$json")
+
+printf '%s\n' '<!-- coverage-report -->'
+printf '## Coverage: %.2f%%\n\n' "$total"
+printf '%s of %s lines covered (Rust unit tests + e2e).\n\n' "$covered" "$count"
+printf '| Crate | Lines | Coverage |\n'
+printf '| --- | --- | --- |\n'
+jq -r --arg root "$root" '
+  .data[0].files
+  | map(select(.filename | startswith($root)))
+  | map(.filename |= ltrimstr($root))
+  | group_by(.filename | split("/")[0])
+  | map({
+      crate: (.[0].filename | split("/")[0]),
+      covered: (map(.summary.lines.covered) | add),
+      count: (map(.summary.lines.count) | add)
+    })
+  | sort_by(.crate)
+  | .[]
+  | "| `\(.crate)` | \(.covered)/\(.count) | \(if .count > 0 then (.covered * 10000 / .count | floor) / 100 else 0 end)% |"
+' "$json"
+
+if [ "$mode" = detail ]; then
+  printf '\n'
+  printf '| File | Lines | Coverage |\n'
+  printf '| --- | --- | --- |\n'
+  jq -r --arg root "$root" '
+    def pct(c; n): if n > 0 then (c * 10000 / n | floor) / 100 else 0 end;
+    .data[0].files
+    | map(select(.filename | startswith($root)))
+    | map(.filename |= ltrimstr($root))
+    | sort_by(.filename)
+    | .[]
+    | "| `\(.filename)` | \(.summary.lines.covered)/\(.summary.lines.count) | \(pct(.summary.lines.covered; .summary.lines.count))% |"
+  ' "$json"
+fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,16 @@
 
 """Pytest configuration and fixtures for end2end tests."""
 
+import os
 import re
+import shlex
+import subprocess
 from pathlib import Path
 
 import pytest
 from fixtures import default_binary_args
+
+PROJECT_ROOT = Path(__file__).parent.parent
 
 # --- Session metadata (shown in HTML report header) ---
 
@@ -23,6 +28,8 @@ def pytest_configure(config):
         for flag in ("--opensovd-profile", "--opensovd-target", "--opensovd-features"):
             if config.getoption(flag):
                 raise pytest.UsageError(f"{flag} has no effect when --opensovd-run is set")
+    if config.getoption("--opensovd-coverage"):
+        _setup_coverage(config)
 
 
 @pytest.hookimpl(optionalhook=True)
@@ -105,6 +112,74 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--opensovd-features", default="", help="Cargo features to enable (comma-separated)"
+    )
+    parser.addoption(
+        "--opensovd-coverage",
+        action="store_true",
+        default=False,
+        help="Instrument the workspace with cargo-llvm-cov; writes coverage.json + HTML + "
+        "Cobertura at session end",
+    )
+
+
+def _setup_coverage(config):
+    """Clean prior coverage data and inject cargo-llvm-cov's instrumentation env.
+
+    Mirrors `source <(cargo llvm-cov show-env --export-prefix)`: the cargo builds
+    and the spawned gateway both inherit os.environ, so RUSTFLAGS instruments the
+    build and LLVM_PROFILE_FILE makes the running gateway emit profile data. Runs
+    from pytest_configure, before collection builds the first test binary.
+    """
+    if config.getoption("--opensovd-run"):
+        raise pytest.UsageError(
+            "--opensovd-coverage requires building from source; it cannot be combined "
+            "with --opensovd-run"
+        )
+    show_env = subprocess.run(
+        ["cargo", "llvm-cov", "show-env"],
+        cwd=PROJECT_ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    for line in show_env.stdout.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            # show-env quotes values; shlex unwraps single/double/unquoted alike.
+            os.environ[key] = shlex.split(value)[0] if value else ""
+    subprocess.run(["cargo", "llvm-cov", "clean", "--workspace"], cwd=PROJECT_ROOT, check=True)
+
+    # Render the report at teardown. Config cleanups run after every
+    # sessionfinish hook (incl. the trylast hook in tests/bruno/conftest.py that
+    # closes the shared gateway), so all instrumented processes have exited and
+    # flushed their profile data. Registered only on success, so the UsageError
+    # path above never triggers a report.
+    config.add_cleanup(_write_coverage_report)
+
+
+def _write_coverage_report():
+    """Render the merged coverage data to coverage.json, HTML, and Cobertura.
+
+    Reads the profile data via the env injected by _setup_coverage; no rebuild.
+    """
+    html_dir = PROJECT_ROOT / "target" / "llvm-cov" / "html"
+    subprocess.run(
+        ["cargo", "llvm-cov", "report", "--json", "--output-path", "coverage.json"],
+        cwd=PROJECT_ROOT,
+        check=True,
+    )
+    subprocess.run(["cargo", "llvm-cov", "report", "--html"], cwd=PROJECT_ROOT, check=True)
+    subprocess.run(
+        [
+            "cargo",
+            "llvm-cov",
+            "report",
+            "--cobertura",
+            "--output-path",
+            str(html_dir / "cobertura.xml"),
+        ],
+        cwd=PROJECT_ROOT,
+        check=True,
     )
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -40,7 +40,7 @@ def _build_crate_binary(config: pytest.Config, crate: str) -> Path:
     project_root = Path(__file__).parent.parent
     target_dir, bin_name = _resolve_bin(project_root, crate)
 
-    cargo_cmd = ["cargo", "build", "-p", crate, "--profile", profile]
+    cargo_cmd = ["cargo", "build", "--locked", "-p", crate, "--profile", profile]
     if target:
         cargo_cmd.extend(["--target", target])
     if features := config.getoption("--opensovd-features"):

--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -44,7 +44,7 @@ def parse_cargo_test_output(output: str) -> list[tuple[str, str]]:
 def list_rust_tests() -> list[tuple[str, str]]:
     """List all Rust tests in the workspace, returning (binary_path, test_name) tuples."""
     result = subprocess.run(
-        ["cargo", "test", "--workspace", "--", "--list"],
+        ["cargo", "test", "--locked", "--workspace", "--all-features", "--", "--list"],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
@@ -79,7 +79,18 @@ def test_rust(rust_test):
         # Run doctest via cargo
         package = binary_path.replace("doctest:", "")
         result = subprocess.run(
-            ["cargo", "test", "-p", package, "--doc", "--", test_name, "--exact"],
+            [
+                "cargo",
+                "test",
+                "--locked",
+                "-p",
+                package,
+                "--doc",
+                "--all-features",
+                "--",
+                test_name,
+                "--exact",
+            ],
             capture_output=True,
         )
     else:


### PR DESCRIPTION
## Summary

Measure coverage across the whole suite (Rust unit/integration/doc + Python e2e) as one merged report.

Local: 213 tests pass, ~87% line coverage.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests