### PR TITLE
ci: pin windows runner to windows-2025-vs2026

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
         include:
           - {os: ubuntu-24.04, target: x86_64-unknown-linux-gnu, profile: release-small, tests: [unittest, pytest]}
           - {os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu, profile: release-small, tests: [unittest]}
-          - {os: windows-2025, target: x86_64-pc-windows-msvc, profile: release-small, tests: [unittest]}
+          - {os: windows-2025-vs2026, target: x86_64-pc-windows-msvc, profile: release-small, tests: [unittest]}
           - {os: macos-15, target: aarch64-apple-darwin, profile: release-small, tests: [unittest]}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Summary

Pin the Windows MSVC build to the `windows-2025-vs2026` runner image. CI reports `NOTICE: windows-2025 requests are being redirected to windows-2025-vs2026 by June 15, 2026`; this adopts the new image (Visual Studio 2026) explicitly so the runner is deterministic and the notice clears.

## Checklist

- [x] I have tested my changes locally
