### PR TITLE
feat: make the pytest e2e harness a reusable plugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,10 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
       - if: contains(matrix.tests, 'pytest')
+        name: opensovd-e2e plugin self-tests
+        run: uv run --locked pytest opensovd-e2e/tests
+
+      - if: contains(matrix.tests, 'pytest')
         uses: actions/setup-node@v6
         with:
           node-version: '22'
@@ -105,7 +109,7 @@ jobs:
 
       - if: contains(matrix.tests, 'pytest')
         run: |
-          uv run pytest tests/ \
+          uv run --locked pytest tests/ \
             --opensovd-target=${{ matrix.target }} \
             --opensovd-profile=${{ matrix.profile }} \
             --html=pytest-report.html \
@@ -193,7 +197,7 @@ jobs:
           cache: false
       - uses: astral-sh/setup-uv@v7
       # Install Python dependencies and tools (prek, ruff, ty)
-      - run: uv sync --group tools
+      - run: uv sync --locked --group tools
       # Cache prek hooks
       - uses: actions/cache@v5
         with:
@@ -202,7 +206,7 @@ jobs:
           restore-keys: |
             prek-${{ runner.os }}-
 
-      - run: uv run prek run --all-files --show-diff-on-failure
+      - run: uv run --locked prek run --all-files --show-diff-on-failure
 
       - name: Validate commit subjects (Conventional Commits)
         if: github.event_name == 'pull_request'
@@ -214,7 +218,7 @@ jobs:
           fail=0
           for sha in $(git rev-list "$BASE_SHA..$HEAD_SHA"); do
             git log -1 --format=%B "$sha" > /tmp/commit-msg
-            if ! uv run prek run --hook-stage commit-msg \
+            if ! uv run --locked prek run --hook-stage commit-msg \
                 --commit-msg-filename /tmp/commit-msg conventional-pre-commit; then
               echo "::error::Non-conventional commit subject: $(git log -1 --format='%h %s' "$sha")"
               fail=1
@@ -330,8 +334,8 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - {binary: opensovd-gateway, dockerfile: docker/Dockerfile.gateway, smoke: 'uv run pytest tests/opensovd-gateway/cli/test_version.py --opensovd-run="docker run --rm opensovd-gateway:test"'}
-          - {binary: opensovd-mcp, dockerfile: docker/Dockerfile.mcp, smoke: 'uv run pytest tests/opensovd-mcp/cli/test_version.py --opensovd-run="docker run --rm opensovd-mcp:test"'}
+          - {binary: opensovd-gateway, dockerfile: docker/Dockerfile.gateway, smoke: 'uv run --locked pytest tests/opensovd-gateway/cli/test_version.py --opensovd-run="docker run --rm opensovd-gateway:test"'}
+          - {binary: opensovd-mcp, dockerfile: docker/Dockerfile.mcp, smoke: 'uv run --locked pytest tests/opensovd-mcp/cli/test_version.py --opensovd-run="docker run --rm opensovd-mcp:test"'}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8

--- a/opensovd-e2e/README.md
+++ b/opensovd-e2e/README.md
@@ -1,0 +1,77 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# opensovd-e2e
+
+Reusable pytest plugin for end-to-end testing of OpenSOVD binaries. It provides
+the generic harness - spawning the binary, waiting for a startup banner,
+capturing output, and requirement traceability - so any OpenSOVD repo can test
+its own binary without duplicating the setup. Project-specific bits (default
+crate, server URL/banner, metadata) are layered on as fixture overrides in the
+consuming repo.
+
+## Install
+
+Depend on it via a Git source (no PyPI publish):
+
+```toml
+# pyproject.toml
+[tool.uv.sources]
+opensovd-e2e = { git = "https://github.com/eclipse-opensovd/opensovd-core", subdirectory = "opensovd-e2e" }
+```
+
+The plugin auto-activates once installed (via its `pytest11` entry point).
+
+For the Requirements column and metadata links in the HTML report, install the
+`html` extra (pulls in `pytest-html`/`pytest-metadata`):
+
+```toml
+[tool.uv.sources]
+opensovd-e2e = { git = "https://github.com/eclipse-opensovd/opensovd-core", subdirectory = "opensovd-e2e", extras = ["html"] }
+```
+
+## Usage
+
+Provide the binary one of two ways:
+
+- `--opensovd-run=<cmd>` - run a prebuilt binary (test args are appended), or
+- override the `crate_binary` fixture - build that crate from the cargo
+  workspace (`--opensovd-profile`/`--opensovd-target`/`--opensovd-features`).
+
+A minimal CLI test using the generic `process` fixture:
+
+```python
+import re
+import pytest
+
+VERSION = re.compile(r"my-binary (\d+\.\d+\.\d+)")
+
+@pytest.fixture(scope="module")
+def crate_binary() -> str:        # build target when --opensovd-run is unset
+    return "my-binary"
+
+@pytest.fixture(scope="module")
+def binary_args() -> list[str]:   # ready_banner defaults to None (no wait)
+    return ["--version"]
+
+def test_version(process):
+    match = process.wait_for(VERSION, timeout_seconds=5.0)
+    process.process.wait(timeout=5.0)
+    assert process.process.returncode == 0
+```
+
+```bash
+uv run pytest --opensovd-run=./target/release/my-binary
+```
+
+## What it provides
+
+- **Options:** `--opensovd-run`, `--opensovd-args`, `--opensovd-profile`,
+  `--opensovd-target`, `--opensovd-features`, `--opensovd-coverage`.
+- **Fixtures:** `crate_binary`, `binary_args`, `ready_banner`, `process`
+  (override any of them for binary-specific behaviour, e.g. an HTTP client).
+- **Requirement traceability:** the `@pytest.mark.req("...")` marker, a
+  Requirements column in the HTML report, and a `requirements-coverage.txt`
+  matrix.

--- a/opensovd-e2e/pyproject.toml
+++ b/opensovd-e2e/pyproject.toml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "opensovd-e2e"
+version = "0.1.0"
+description = "Reusable pytest plugin for OpenSOVD end-to-end binary tests"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.13"
+keywords = ["pytest", "opensovd", "e2e"]
+classifiers = [
+    "Framework :: Pytest",
+    "Programming Language :: Python :: 3",
+]
+dependencies = ["pytest>=9"]
+
+[project.optional-dependencies]
+# Enables the Requirements column and metadata links in the HTML report.
+html = ["pytest-html>=4", "pytest-metadata>=3"]
+
+# Auto-load the plugin in any project that installs this package, so consumers
+# get --opensovd-run and the base fixtures without wiring up pytest_plugins.
+[project.entry-points.pytest11]
+opensovd_e2e = "opensovd_e2e.plugin"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opensovd_e2e"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/opensovd-e2e/src/opensovd_e2e/__init__.py
+++ b/opensovd-e2e/src/opensovd_e2e/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable pytest plugin and helpers for OpenSOVD end-to-end binary tests."""
+
+from opensovd_e2e.process import ProcessUnderTest, spawn_process
+
+__all__ = [
+    "ProcessUnderTest",
+    "spawn_process",
+]

--- a/opensovd-e2e/src/opensovd_e2e/plugin.py
+++ b/opensovd-e2e/src/opensovd_e2e/plugin.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic pytest plugin for end-to-end testing of OpenSOVD binaries."""
+
+import os
+import re
+import shlex
+import subprocess
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+from opensovd_e2e.process import ProcessUnderTest, spawn_process
+
+# Stored in pytest_configure for later access in report hooks.
+_config = None
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--opensovd-run",
+        default=None,
+        help="Command prefix to run instead of building from source; test args are appended",
+    )
+    parser.addoption(
+        "--opensovd-args",
+        default="",
+        help="Additional arguments to pass to the binary",
+    )
+    parser.addoption(
+        "--opensovd-profile",
+        default=None,
+        help="Cargo profile to build (default: dev; e.g. release, release-small)",
+    )
+    parser.addoption(
+        "--opensovd-target",
+        default=None,
+        help="Cargo --target triple; needed when artifacts live under target/<triple>/...",
+    )
+    parser.addoption(
+        "--opensovd-features", default="", help="Cargo features to enable (comma-separated)"
+    )
+    parser.addoption(
+        "--opensovd-coverage",
+        action="store_true",
+        default=False,
+        help="Instrument the workspace with cargo-llvm-cov; writes coverage.json + HTML + "
+        "Cobertura at session end",
+    )
+
+
+def pytest_configure(config):
+    """Store config for report hooks, validate options, register the req marker."""
+    global _config
+    _config = config
+    config.addinivalue_line(
+        "markers", "req(id): requirement ID for traceability (e.g. req('SOVD-7.1.1'))"
+    )
+    if config.getoption("--opensovd-run"):
+        for flag in ("--opensovd-profile", "--opensovd-target", "--opensovd-features"):
+            if config.getoption(flag):
+                raise pytest.UsageError(f"{flag} has no effect when --opensovd-run is set")
+    if config.getoption("--opensovd-coverage"):
+        _setup_coverage(config)
+
+
+def _setup_coverage(config):
+    """Clean prior coverage data and inject cargo-llvm-cov's instrumentation env.
+
+    Mirrors `source <(cargo llvm-cov show-env --export-prefix)`: the cargo builds
+    and the spawned binary both inherit os.environ, so RUSTFLAGS instruments the
+    build and LLVM_PROFILE_FILE makes the running binary emit profile data. Runs
+    from pytest_configure, before collection builds the first test binary.
+    """
+    if config.getoption("--opensovd-run"):
+        raise pytest.UsageError(
+            "--opensovd-coverage requires building from source; it cannot be combined "
+            "with --opensovd-run"
+        )
+    project_root = Path(config.rootpath)
+    show_env = subprocess.run(
+        ["cargo", "llvm-cov", "show-env"],
+        cwd=project_root,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    for line in show_env.stdout.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            # show-env quotes values; shlex unwraps single/double/unquoted alike.
+            os.environ[key] = shlex.split(value)[0] if value else ""
+    subprocess.run(["cargo", "llvm-cov", "clean", "--workspace"], cwd=project_root, check=True)
+
+    # Render the report at teardown. Config cleanups run after every
+    # sessionfinish hook (incl. the trylast hook in tests/bruno/conftest.py that
+    # closes the shared gateway), so all instrumented processes have exited and
+    # flushed their profile data. Registered only on success, so the UsageError
+    # path above never triggers a report.
+    config.add_cleanup(lambda: _write_coverage_report(project_root))
+
+
+def _write_coverage_report(project_root: Path):
+    """Render the merged coverage data to coverage.json, HTML, and Cobertura.
+
+    Reads the profile data via the env injected by _setup_coverage; no rebuild.
+    """
+    html_dir = project_root / "target" / "llvm-cov" / "html"
+    subprocess.run(
+        ["cargo", "llvm-cov", "report", "--json", "--output-path", "coverage.json"],
+        cwd=project_root,
+        check=True,
+    )
+    subprocess.run(["cargo", "llvm-cov", "report", "--html"], cwd=project_root, check=True)
+    subprocess.run(
+        [
+            "cargo",
+            "llvm-cov",
+            "report",
+            "--cobertura",
+            "--output-path",
+            str(html_dir / "cobertura.xml"),
+        ],
+        cwd=project_root,
+        check=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def crate_binary() -> str | None:
+    """Cargo crate binary to build/run when ``--opensovd-run`` is unset.
+
+    No generic default. Consumers override this with their crate name (e.g.
+    ``opensovd-gateway``). Unused when ``--opensovd-run`` is
+    given, which is the path consumers without an in-tree crate take.
+    """
+    return None
+
+
+@pytest.fixture(scope="module")
+def binary_args(request) -> list[str]:
+    """Arguments passed to the binary.
+
+    Generic default is just the ``--opensovd-args`` passthrough. Consumers
+    override to inject binary-specific defaults (e.g. a server ``--url``).
+    """
+    return shlex.split(request.config.getoption("--opensovd-args"))
+
+
+@pytest.fixture(scope="module")
+def ready_banner() -> re.Pattern | None:
+    """Pattern to wait for in stdout before treating the process as ready.
+
+    Default is None (no wait). Suitable for CLI commands like ``--version``
+    that print and exit. Consumers override for long-running servers.
+    """
+    return None
+
+
+@pytest.fixture(scope="module")
+def process(request, crate_binary, binary_args, ready_banner) -> ProcessUnderTest:
+    """Generic process-under-test fixture.
+
+    Spawns the binary (or the ``--opensovd-run`` command) with ``binary_args``
+    and waits for ``ready_banner`` (None = no wait). Consumers may build richer
+    fixtures (e.g. an HTTP client) on top of this.
+    """
+    proc = spawn_process(
+        request.config,
+        binary_args,
+        ready_banner,
+        crate=crate_binary,
+    )
+    yield proc
+    proc.close()
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_html_results_summary(prefix, summary, postfix):
+    """Render metadata keys ending in _URL as clickable links at the top."""
+    if _config is None:
+        return
+    try:
+        from pytest_metadata.plugin import metadata_key
+    except ImportError:
+        return
+
+    metadata = _config.stash.get(metadata_key, {})
+    for key, url in list(metadata.items()):
+        if key.endswith("_URL") and url:
+            label = key.replace("_URL", "").replace("_", " ")
+            prefix.append(f'<p><strong>{label}:</strong> <a href="{url}">{url}</a></p>')
+            del metadata[key]  # Remove from Environment table to avoid duplication
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_html_results_table_header(cells):
+    """Add Requirements column to HTML report table."""
+    cells.insert(2, "<th>Requirements</th>")
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_html_results_table_row(report, cells):
+    """Populate Requirements column for each test."""
+    reqs = ", ".join(report.req) if hasattr(report, "req") and report.req else ""
+    cells.insert(2, f"<td>{reqs}</td>")
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Generate requirements traceability matrix."""
+    req_map: dict[str, list[str]] = {}
+    for item in session.items:
+        for marker in item.iter_markers(name="req"):
+            for req_id in marker.args:
+                req_map.setdefault(req_id, []).append(item.nodeid)
+
+    if req_map:
+        output = Path(session.config.rootpath) / "requirements-coverage.txt"
+        with output.open("w") as f:
+            f.write("# Requirements Traceability Matrix\n")
+            f.write(f"# Total requirements covered: {len(req_map)}\n\n")
+            for req_id, tests in sorted(req_map.items()):
+                f.write(f"{req_id}:\n")
+                for test in sorted(tests):
+                    f.write(f"  - {test}\n")
+
+
+def _find_process(funcargs: Iterable) -> ProcessUnderTest | None:
+    """Find the ProcessUnderTest among a test's fixture values, if any.
+
+    Matches a process fixture directly, or one held as an attribute on a
+    client/wrapper fixture (e.g. a SovdClient holding its server process).
+    """
+    values = list(funcargs)
+    for val in values:
+        if isinstance(val, ProcessUnderTest):
+            return val
+    for val in values:
+        for inner in vars(val).values() if hasattr(val, "__dict__") else ():
+            if isinstance(inner, ProcessUnderTest):
+                return inner
+    return None
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Capture req markers for the report, and process output on failure."""
+    outcome = yield
+    report = outcome.get_result()
+
+    # Capture requirement markers for HTML report
+    markers = list(item.iter_markers(name="req"))
+    report.req = [arg for m in markers for arg in m.args]
+
+    # Capture process output on failure
+    if report.failed and hasattr(item, "funcargs"):
+        proc = _find_process(item.funcargs.values())
+        if proc and proc.has_output and not proc._output_printed:
+            proc._output_printed = True
+            report.sections.append(("Process Output", proc.stdout))

--- a/opensovd-e2e/src/opensovd_e2e/process.py
+++ b/opensovd-e2e/src/opensovd_e2e/process.py
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared test fixtures and utilities for the process under test."""
+
+import functools
+import json
+import re
+import shlex
+import subprocess
+import sysconfig
+import threading
+import time
+from pathlib import Path
+from typing import Self
+
+import pytest
+
+# Timeout constants (seconds)
+PROCESS_SPAWN_TIMEOUT = 30.0
+PROCESS_WAIT_TIMEOUT = 1.0
+PROCESS_TERMINATE_TIMEOUT = 5.0
+
+
+def _build_crate_binary(config: pytest.Config, crate: str) -> Path:
+    """Build the opensovd binary for the given crate via cargo.
+
+    Args:
+        config: pytest configuration object
+        crate: cargo workspace package name to build
+
+    Returns:
+        Path to the opensovd binary, resolved via `cargo metadata`
+    """
+    profile = config.getoption("--opensovd-profile") or "dev"
+    target = config.getoption("--opensovd-target")
+
+    # The cargo workspace root is the pytest rootdir (the project's
+    # pyproject.toml directory), not this file's location: the plugin may be
+    # installed elsewhere (site-packages, a git checkout) than the crate under
+    # test. Consumers that ship no crate use --opensovd-run and never reach here.
+    project_root = Path(config.rootpath)
+    target_dir, binary_name = _resolve_binary(project_root, crate)
+
+    cargo_cmd = ["cargo", "build", "--locked", "-p", crate, "--profile", profile]
+    if target:
+        cargo_cmd.extend(["--target", target])
+    if features := config.getoption("--opensovd-features"):
+        cargo_cmd.extend(["--features", features])
+
+    subprocess.run(
+        cargo_cmd,
+        cwd=project_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=True,
+    )
+
+    # cargo writes the dev profile to target/[<triple>/]debug/, every other
+    # profile to a directory matching its name.
+    artifact_dir = "debug" if profile == "dev" else profile
+    base = target_dir / target if target else target_dir
+    exe_suffix = sysconfig.get_config_var("EXE") or ""
+    binary_path = base / artifact_dir / f"{binary_name}{exe_suffix}"
+
+    # Surface what was built in the HTML report, reusing the cached metadata.
+    version = next(
+        (
+            p.get("version", "")
+            for p in _cargo_metadata(project_root).get("packages", [])
+            if p.get("name") == crate
+        ),
+        "",
+    )
+    _record_metadata(
+        config,
+        **{
+            f"Crate ({crate})": f"{crate} {version}".strip(),
+            f"Binary ({crate})": str(binary_path),
+            "Cargo Profile": profile,
+            "Cargo Target": target or "",
+        },
+    )
+    return binary_path
+
+
+@functools.cache
+def _cargo_metadata(project_root: Path) -> dict:
+    """Parsed `cargo metadata --no-deps` for the workspace at `project_root`.
+
+    Cached so the single shell-out is shared by binary resolution and report
+    metadata; both read crate info from the same result.
+    """
+    cmd = ["cargo", "metadata", "--format-version=1", "--no-deps"]
+    result = subprocess.run(cmd, cwd=project_root, capture_output=True, check=True)
+    return json.loads(result.stdout)
+
+
+def _resolve_binary(project_root: Path, crate: str) -> tuple[Path, str]:
+    """Return (target_directory, binary_name) for `crate` via `cargo metadata`."""
+    metadata = _cargo_metadata(project_root)
+    target_dir = Path(metadata["target_directory"])
+    for pkg in metadata.get("packages", []):
+        if pkg.get("name") != crate:
+            continue
+        # "bin" is cargo's target-kind string for an executable target.
+        binaries = [t for t in pkg.get("targets", []) if "bin" in (t.get("kind") or [])]
+        if not binaries:
+            raise RuntimeError(f"crate {crate!r} has no binary targets")
+        for t in binaries:
+            if t.get("name") == crate:
+                return target_dir, t["name"]
+        if len(binaries) == 1:
+            return target_dir, binaries[0]["name"]
+        names = ", ".join(sorted(t.get("name", "") for t in binaries))
+        raise RuntimeError(
+            f"crate {crate!r} has multiple binaries ({names}); none matched the crate name"
+        )
+    raise RuntimeError(f"crate {crate!r} not found in workspace metadata")
+
+
+def _record_metadata(config: pytest.Config, **entries: str) -> None:
+    """Add entries to the pytest-metadata report dict, if that plugin is present.
+
+    No-op when pytest-metadata is unavailable (it lives in the optional ``html``
+    extra), mirroring the report hooks in plugin.py. Empty values are skipped.
+    """
+    try:
+        from pytest_metadata.plugin import metadata_key
+    except ImportError:
+        return
+    md = config.stash.get(metadata_key, None)
+    if md is None:
+        return
+    for key, value in entries.items():
+        if value:
+            md[key] = value
+
+
+class ProcessUnderTest:
+    def __init__(self, process: subprocess.Popen | None = None):
+        self.process = process
+        self._output: list[str] = []
+        self._line_event = threading.Event()
+        self._lock = threading.Lock()
+        self._read_pos = 0
+        self._closed = False
+        self._reader_thread: threading.Thread | None = None
+        if process and process.stdout:
+            self._reader_thread = threading.Thread(target=self._read_output, daemon=True)
+            self._reader_thread.start()
+        self.match: re.Match | None = None
+        self._output_printed = False
+
+    @classmethod
+    def spawn(
+        cls,
+        cmd: list[str],
+        timeout_seconds: float = PROCESS_SPAWN_TIMEOUT,
+        env: dict | None = None,
+        ready_banner: re.Pattern | None = None,
+    ) -> Self:
+        """Spawn process, wait for banner, return ready ProcessUnderTest.
+
+        Args:
+            cmd: Command to execute
+            timeout_seconds: Maximum seconds to wait for banner
+            env: Environment variables for the process
+            ready_banner: Pattern to wait for before considering ready (None
+                to skip). The `re.Match` is stored on `.match` for consumers.
+        """
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+
+        proc = cls(process)
+        if ready_banner is None:
+            return proc
+
+        try:
+            proc.match = proc.wait_for(ready_banner, timeout_seconds)
+            return proc
+        except (TimeoutError, RuntimeError) as e:
+            proc.close()  # close the pipe's write end so the reader hits EOF
+            output = proc.stdout  # returncode now set -> stdout drains the reader fully
+            if output:
+                e.add_note(f"Process Output:\n{output}")
+            raise
+
+    @property
+    def has_output(self) -> bool:
+        with self._lock:
+            return len(self._output) > 0
+
+    @property
+    def stdout(self) -> str:
+        # If process exited, wait for reader thread to finish draining the pipe
+        if self.process and self.process.returncode is not None and self._reader_thread:
+            self._reader_thread.join(timeout=1.0)
+        with self._lock:
+            return "".join(self._output)
+
+    def wait_for(
+        self,
+        pattern: str | re.Pattern,
+        timeout_seconds: float = PROCESS_WAIT_TIMEOUT,
+    ) -> re.Match[str]:
+        """Wait for a line matching pattern in stdout.
+
+        Args:
+            pattern: String or compiled regex to match against lines
+            timeout_seconds: Maximum seconds to wait
+
+        Returns:
+            The match object (use .string for full line, .group() for matched text)
+
+        Raises:
+            RuntimeError: If process exits before pattern matched
+            TimeoutError: If no matching line found within timeout
+        """
+        if isinstance(pattern, str):
+            pattern = re.compile(re.escape(pattern))
+
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            # Clear before checking so a set() that races with the drain
+            # below still wakes the next wait().
+            self._line_event.clear()
+            with self._lock:
+                while self._read_pos < len(self._output):
+                    line = self._output[self._read_pos]
+                    self._read_pos += 1
+                    if match := pattern.search(line):
+                        return match
+            if self._closed:
+                raise RuntimeError("Process exited before pattern matched")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"Pattern {pattern.pattern!r} not found within {timeout_seconds}s"
+                )
+            self._line_event.wait(timeout=remaining)
+
+    def close(self):
+        if self.process and self.process.returncode is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=PROCESS_TERMINATE_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=PROCESS_TERMINATE_TIMEOUT)
+        if self._reader_thread:
+            self._reader_thread.join(timeout=PROCESS_TERMINATE_TIMEOUT)
+        if self.process and self.process.stdout:
+            self.process.stdout.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def _read_output(self):
+        """Read stdout in background thread."""
+        stdout = self.process.stdout if self.process else None
+        if stdout is None:
+            self._closed = True
+            self._line_event.set()
+            return
+        try:
+            for line in stdout:
+                with self._lock:
+                    self._output.append(line)
+                self._line_event.set()
+        finally:
+            self._closed = True
+            self._line_event.set()
+
+
+def spawn_process(
+    config: pytest.Config,
+    args: list[str],
+    ready_banner: re.Pattern | None = None,
+    crate: str | None = None,
+) -> ProcessUnderTest:
+    """Spawn the process under test with the given arguments.
+
+    A helper for tests that need custom configurations; most tests use the
+    generic module-scoped ``process`` fixture instead.
+
+    Args:
+        config: pytest configuration object
+        args: Command-line arguments to pass after the run command / binary
+        ready_banner: Pattern to wait for before considering ready (None to
+            skip). The match is stored on ProcessUnderTest.match for consumers.
+        crate: cargo workspace package name to build when --opensovd-run is
+            unset; required on that path.
+
+    Returns:
+        A running ProcessUnderTest instance (caller must call close())
+    """
+    run_cmd = config.getoption("--opensovd-run")
+    if run_cmd:
+        cmd = [*shlex.split(run_cmd), *args]
+        _record_metadata(config, **{"Binary (prebuilt)": run_cmd})
+    else:
+        if crate is None:
+            raise pytest.UsageError(
+                "no crate to build: pass --opensovd-run or override crate_binary"
+            )
+        binary_path = _build_crate_binary(config, crate)
+        cmd = [str(binary_path), *args]
+    return ProcessUnderTest.spawn(cmd, ready_banner=ready_banner)

--- a/opensovd-e2e/tests/conftest.py
+++ b/opensovd-e2e/tests/conftest.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+pytest_plugins = ["pytester"]

--- a/opensovd-e2e/tests/test_plugin.py
+++ b/opensovd-e2e/tests/test_plugin.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Self-tests for the opensovd_e2e plugin, driven via pytest's pytester."""
+
+# The plugin is loaded into each inner run explicitly (-p), since it is not
+# pip-installed in this dev checkout (no pytest11 auto-discovery here).
+PLUGIN = ("-p", "opensovd_e2e.plugin")
+
+
+def test_registers_options(pytester):
+    """The plugin contributes its --opensovd-* options."""
+    result = pytester.runpytest(*PLUGIN, "--help")
+    result.stdout.fnmatch_lines(["*--opensovd-run*"])
+
+
+def test_registers_req_marker(pytester):
+    """The req traceability marker is self-registered (no unknown-mark warning)."""
+    result = pytester.runpytest(*PLUGIN, "--markers")
+    result.stdout.fnmatch_lines(["*@pytest.mark.req*"])
+
+
+def test_process_fixture_runs_command(pytester):
+    """The generic `process` fixture spawns --opensovd-run and captures output."""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.fixture(scope="module")
+        def binary_args():
+            return ["hello"]
+
+        def test_echo(process):
+            process.wait_for("hello", timeout_seconds=5.0)
+            process.process.wait(timeout=5.0)
+            assert process.process.returncode == 0
+        """
+    )
+    result = pytester.runpytest(*PLUGIN, "--opensovd-run=echo")
+    result.assert_outcomes(passed=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["tests"]
+pythonpath = ["tests", "opensovd-e2e/src"]
 # importlib mode lets per-crate dirs (opensovd-gateway/cli/, opensovd-mcp/cli/)
 # share filenames like test_version.py without basename collisions.
 addopts = "--import-mode=importlib"
@@ -32,7 +32,7 @@ markers = [
     "conformance: Conformance tests (require bru CLI)",
     "schema: Tests that validate response schema",
     "bruno: Bruno API conformance tests",
-    "req: Requirement ID for traceability (e.g., @pytest.mark.req('SOVD-7.1.1'))",
+    # "req" marker is registered by the opensovd_e2e plugin.
 ]
 
 [tool.ruff]
@@ -60,4 +60,4 @@ select = [
 include = ["tests"]
 
 [tool.ty.environment]
-extra-paths = ["tests"]
+extra-paths = ["tests", "opensovd-e2e/src"]

--- a/tests/bruno/conftest.py
+++ b/tests/bruno/conftest.py
@@ -7,7 +7,8 @@ import shutil
 import subprocess
 
 import pytest
-from fixtures import LISTENING_PATTERN, default_binary_args, listening_url, spawn_process
+from fixtures import LISTENING_PATTERN, default_binary_args, listening_url
+from opensovd_e2e import spawn_process
 
 
 def pytest_collect_file(parent, file_path):
@@ -30,7 +31,12 @@ def pytest_runtest_setup(item):
         pytest.skip("bru CLI not installed")
 
     if not hasattr(item.config, "_bruno_process"):
-        proc = spawn_process(item.config, default_binary_args(item.config), LISTENING_PATTERN)
+        proc = spawn_process(
+            item.config,
+            default_binary_args(item.config),
+            LISTENING_PATTERN,
+            crate="opensovd-gateway",
+        )
         item.config._bruno_process = proc
         if proc.match is not None:
             item.config._gateway_base_url = listening_url(proc.match)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,227 +1,27 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Pytest configuration and fixtures for end2end tests."""
-
-import os
-import re
-import shlex
-import subprocess
-from pathlib import Path
+"""Pytest config: load the opensovd_e2e plugin, add OpenSOVD-core overrides."""
 
 import pytest
 from fixtures import default_binary_args
 
-PROJECT_ROOT = Path(__file__).parent.parent
-
-# --- Session metadata (shown in HTML report header) ---
-
-# Module-level variable to store config for later access
-_config = None
+pytest_plugins = ["opensovd_e2e.plugin"]
 
 
-def pytest_configure(config):
-    """Store config for later access in other hooks."""
-    global _config
-    _config = config
-    if config.getoption("--opensovd-run"):
-        for flag in ("--opensovd-profile", "--opensovd-target", "--opensovd-features"):
-            if config.getoption(flag):
-                raise pytest.UsageError(f"{flag} has no effect when --opensovd-run is set")
-    if config.getoption("--opensovd-coverage"):
-        _setup_coverage(config)
+@pytest.fixture(scope="module")
+def crate_binary() -> str:
+    """Default crate for the in-repo suite (override per crate dir, e.g. mcp)."""
+    return "opensovd-gateway"
+
+
+@pytest.fixture(scope="module")
+def binary_args(request) -> list[str]:
+    """Inject an ephemeral server ``--url`` by default (SOVD HTTP server)."""
+    return default_binary_args(request.config)
 
 
 @pytest.hookimpl(optionalhook=True)
 def pytest_metadata(metadata):
     """Add project metadata to the test report (pytest-metadata hook)."""
     metadata["SOVD Version"] = "1.1.0"
-
-
-@pytest.hookimpl(optionalhook=True)
-def pytest_html_results_summary(prefix, summary, postfix):
-    """Render metadata keys ending in _URL as clickable links at the top."""
-    if _config is None:
-        return
-    try:
-        from pytest_metadata.plugin import metadata_key
-    except ImportError:
-        return
-
-    metadata = _config.stash.get(metadata_key, {})
-    for key, url in list(metadata.items()):
-        if key.endswith("_URL") and url:
-            label = key.replace("_URL", "").replace("_", " ")
-            prefix.append(f'<p><strong>{label}:</strong> <a href="{url}">{url}</a></p>')
-            del metadata[key]  # Remove from Environment table to avoid duplication
-
-
-# --- Requirement tracking for HTML report ---
-
-
-def pytest_html_results_table_header(cells):
-    """Add Requirements column to HTML report table."""
-    cells.insert(2, "<th>Requirements</th>")
-
-
-def pytest_html_results_table_row(report, cells):
-    """Populate Requirements column for each test."""
-    reqs = ", ".join(report.req) if hasattr(report, "req") and report.req else ""
-    cells.insert(2, f"<td>{reqs}</td>")
-
-
-def pytest_sessionfinish(session, exitstatus):
-    """Generate requirements traceability matrix."""
-    req_map: dict[str, list[str]] = {}
-    for item in session.items:
-        for marker in item.iter_markers(name="req"):
-            for req_id in marker.args:
-                req_map.setdefault(req_id, []).append(item.nodeid)
-
-    if req_map:
-        output = Path("requirements-coverage.txt")
-        with output.open("w") as f:
-            f.write("# Requirements Traceability Matrix\n")
-            f.write(f"# Total requirements covered: {len(req_map)}\n\n")
-            for req_id, tests in sorted(req_map.items()):
-                f.write(f"{req_id}:\n")
-                for test in sorted(tests):
-                    f.write(f"  - {test}\n")
-
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--opensovd-run",
-        default=None,
-        help="Command prefix to run instead of building from source; test args are appended",
-    )
-    parser.addoption(
-        "--opensovd-args",
-        default="",
-        help="Additional arguments to pass to the binary",
-    )
-    parser.addoption(
-        "--opensovd-profile",
-        default=None,
-        help="Cargo profile to build (default: dev; e.g. release, release-small)",
-    )
-    parser.addoption(
-        "--opensovd-target",
-        default=None,
-        help="Cargo --target triple; needed when artifacts live under target/<triple>/...",
-    )
-    parser.addoption(
-        "--opensovd-features", default="", help="Cargo features to enable (comma-separated)"
-    )
-    parser.addoption(
-        "--opensovd-coverage",
-        action="store_true",
-        default=False,
-        help="Instrument the workspace with cargo-llvm-cov; writes coverage.json + HTML + "
-        "Cobertura at session end",
-    )
-
-
-def _setup_coverage(config):
-    """Clean prior coverage data and inject cargo-llvm-cov's instrumentation env.
-
-    Mirrors `source <(cargo llvm-cov show-env --export-prefix)`: the cargo builds
-    and the spawned gateway both inherit os.environ, so RUSTFLAGS instruments the
-    build and LLVM_PROFILE_FILE makes the running gateway emit profile data. Runs
-    from pytest_configure, before collection builds the first test binary.
-    """
-    if config.getoption("--opensovd-run"):
-        raise pytest.UsageError(
-            "--opensovd-coverage requires building from source; it cannot be combined "
-            "with --opensovd-run"
-        )
-    show_env = subprocess.run(
-        ["cargo", "llvm-cov", "show-env"],
-        cwd=PROJECT_ROOT,
-        check=True,
-        stdout=subprocess.PIPE,
-        text=True,
-    )
-    for line in show_env.stdout.splitlines():
-        key, sep, value = line.partition("=")
-        if sep:
-            # show-env quotes values; shlex unwraps single/double/unquoted alike.
-            os.environ[key] = shlex.split(value)[0] if value else ""
-    subprocess.run(["cargo", "llvm-cov", "clean", "--workspace"], cwd=PROJECT_ROOT, check=True)
-
-    # Render the report at teardown. Config cleanups run after every
-    # sessionfinish hook (incl. the trylast hook in tests/bruno/conftest.py that
-    # closes the shared gateway), so all instrumented processes have exited and
-    # flushed their profile data. Registered only on success, so the UsageError
-    # path above never triggers a report.
-    config.add_cleanup(_write_coverage_report)
-
-
-def _write_coverage_report():
-    """Render the merged coverage data to coverage.json, HTML, and Cobertura.
-
-    Reads the profile data via the env injected by _setup_coverage; no rebuild.
-    """
-    html_dir = PROJECT_ROOT / "target" / "llvm-cov" / "html"
-    subprocess.run(
-        ["cargo", "llvm-cov", "report", "--json", "--output-path", "coverage.json"],
-        cwd=PROJECT_ROOT,
-        check=True,
-    )
-    subprocess.run(["cargo", "llvm-cov", "report", "--html"], cwd=PROJECT_ROOT, check=True)
-    subprocess.run(
-        [
-            "cargo",
-            "llvm-cov",
-            "report",
-            "--cobertura",
-            "--output-path",
-            str(html_dir / "cobertura.xml"),
-        ],
-        cwd=PROJECT_ROOT,
-        check=True,
-    )
-
-
-@pytest.fixture(scope="module")
-def crate_bin() -> str:
-    """Cargo crate bin to build and run.
-
-    Override per test module/directory to target a different crate
-    (e.g. opensovd-mcp). The default is the gateway.
-    """
-    return "opensovd-gateway"
-
-
-@pytest.fixture(scope="module")
-def binary_args(request) -> list[str]:
-    return default_binary_args(request.config)
-
-
-@pytest.fixture(scope="module")
-def ready_banner() -> re.Pattern | None:
-    """Pattern to wait for in stdout before treating the process as ready.
-
-    Default is None (no banner). Crate-specific conftests override.
-    """
-    return None
-
-
-@pytest.hookimpl(tryfirst=True, hookwrapper=True)
-def pytest_runtest_makereport(item, call):
-    outcome = yield
-    report = outcome.get_result()
-
-    # Capture requirement markers for HTML report
-    markers = list(item.iter_markers(name="req"))
-    report.req = [arg for m in markers for arg in m.args]
-
-    # Capture process output on failure
-    if report.failed and hasattr(item, "funcargs"):
-        proc = item.funcargs.get("gateway") or item.funcargs.get("mcp")
-        if proc is None:
-            client = item.funcargs.get("client")
-            proc = client.gateway if client is not None else None
-        if proc and proc.has_output and not proc._output_printed:
-            proc._output_printed = True
-            report.sections.append(("Process Output", proc.stdout))

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,277 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared test fixtures and utilities for the process under test."""
+"""OpenSOVD-core test helpers: server startup-banner pattern, URL mapping, --url args."""
 
-import functools
-import json
 import re
 import shlex
-import subprocess
-import sysconfig
-import threading
-import time
-from pathlib import Path
-from typing import Self
 
 import pytest
 
-# Timeout constants (seconds)
-PROCESS_SPAWN_TIMEOUT = 30.0
-PROCESS_WAIT_TIMEOUT = 1.0
-PROCESS_TERMINATE_TIMEOUT = 5.0
-
+# The OpenSOVD server announces its bound address on stdout in this form:
+#   Listening addr=127.0.0.1:7690 type=tcp base=/sovd
 LISTENING_PATTERN = re.compile(r"Listening addr=(\S+) type=(tcp|unix|abstract|tls) base=(\S+)")
-
-
-def _build_crate_binary(config: pytest.Config, crate: str) -> Path:
-    """Build the opensovd binary for the given crate via cargo.
-
-    Args:
-        config: pytest configuration object
-        crate: cargo workspace package name to build
-
-    Returns:
-        Path to the opensovd binary, resolved via `cargo metadata`
-    """
-    profile = config.getoption("--opensovd-profile") or "dev"
-    target = config.getoption("--opensovd-target")
-
-    project_root = Path(__file__).parent.parent
-    target_dir, bin_name = _resolve_bin(project_root, crate)
-
-    cargo_cmd = ["cargo", "build", "--locked", "-p", crate, "--profile", profile]
-    if target:
-        cargo_cmd.extend(["--target", target])
-    if features := config.getoption("--opensovd-features"):
-        cargo_cmd.extend(["--features", features])
-
-    subprocess.run(
-        cargo_cmd,
-        cwd=project_root,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        check=True,
-    )
-
-    # cargo writes the dev profile to target/[<triple>/]debug/, every other
-    # profile to a directory matching its name.
-    artifact_dir = "debug" if profile == "dev" else profile
-    base = target_dir / target if target else target_dir
-    exe_suffix = sysconfig.get_config_var("EXE") or ""
-    return base / artifact_dir / f"{bin_name}{exe_suffix}"
-
-
-@functools.cache
-def _resolve_bin(project_root: Path, crate: str) -> tuple[Path, str]:
-    """Return (target_directory, bin_name) for `crate` via `cargo metadata`."""
-    cmd = ["cargo", "metadata", "--format-version=1", "--no-deps"]
-    result = subprocess.run(cmd, cwd=project_root, capture_output=True, check=True)
-
-    metadata = json.loads(result.stdout)
-    target_dir = Path(metadata["target_directory"])
-    for pkg in metadata.get("packages", []):
-        if pkg.get("name") != crate:
-            continue
-        bins = [t for t in pkg.get("targets", []) if "bin" in (t.get("kind") or [])]
-        if not bins:
-            raise RuntimeError(f"crate {crate!r} has no bin targets")
-        for t in bins:
-            if t.get("name") == crate:
-                return target_dir, t["name"]
-        if len(bins) == 1:
-            return target_dir, bins[0]["name"]
-        names = ", ".join(sorted(t.get("name", "") for t in bins))
-        raise RuntimeError(
-            f"crate {crate!r} has multiple bins ({names}); none matched the crate name"
-        )
-    raise RuntimeError(f"crate {crate!r} not found in workspace metadata")
-
-
-class ProcessUnderTest:
-    def __init__(self, process: subprocess.Popen | None = None):
-        self.process = process
-        self._output: list[str] = []
-        self._line_event = threading.Event()
-        self._lock = threading.Lock()
-        self._read_pos = 0
-        self._closed = False
-        self._reader_thread: threading.Thread | None = None
-        if process and process.stdout:
-            self._reader_thread = threading.Thread(target=self._read_output, daemon=True)
-            self._reader_thread.start()
-        self.match: re.Match | None = None
-        self._output_printed = False
-
-    @classmethod
-    def spawn(
-        cls,
-        cmd: list[str],
-        timeout_seconds: float = PROCESS_SPAWN_TIMEOUT,
-        env: dict | None = None,
-        ready_banner: re.Pattern | None = None,
-    ) -> Self:
-        """Spawn process, wait for banner, return ready ProcessUnderTest.
-
-        Args:
-            cmd: Command to execute
-            timeout_seconds: Maximum seconds to wait for banner
-            env: Environment variables for the process
-            ready_banner: Pattern to wait for before considering ready (None
-                to skip). The `re.Match` is stored on `.match` for consumers.
-        """
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            env=env,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-        )
-
-        proc = cls(process)
-        if ready_banner is None:
-            return proc
-
-        try:
-            proc.match = proc.wait_for(ready_banner, timeout_seconds)
-            return proc
-        except (TimeoutError, RuntimeError) as e:
-            output = proc.stdout
-            proc.close()
-            if output:
-                e.add_note(f"Process Output:\n{output}")
-            raise
-
-    @property
-    def has_output(self) -> bool:
-        with self._lock:
-            return len(self._output) > 0
-
-    @property
-    def stdout(self) -> str:
-        # If process exited, wait for reader thread to finish draining the pipe
-        if self.process and self.process.returncode is not None and self._reader_thread:
-            self._reader_thread.join(timeout=1.0)
-        with self._lock:
-            return "".join(self._output)
-
-    def wait_for(
-        self,
-        pattern: str | re.Pattern,
-        timeout_seconds: float = PROCESS_WAIT_TIMEOUT,
-    ) -> re.Match[str]:
-        """Wait for a line matching pattern in stdout.
-
-        Args:
-            pattern: String or compiled regex to match against lines
-            timeout_seconds: Maximum seconds to wait
-
-        Returns:
-            The match object (use .string for full line, .group() for matched text)
-
-        Raises:
-            RuntimeError: If process exits before pattern matched
-            TimeoutError: If no matching line found within timeout
-        """
-        if isinstance(pattern, str):
-            pattern = re.compile(re.escape(pattern))
-
-        deadline = time.monotonic() + timeout_seconds
-        while True:
-            # Clear before checking so a set() that races with the drain
-            # below still wakes the next wait().
-            self._line_event.clear()
-            with self._lock:
-                while self._read_pos < len(self._output):
-                    line = self._output[self._read_pos]
-                    self._read_pos += 1
-                    if match := pattern.search(line):
-                        return match
-            if self._closed:
-                raise RuntimeError("Process exited before pattern matched")
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise TimeoutError(
-                    f"Pattern {pattern.pattern!r} not found within {timeout_seconds}s"
-                )
-            self._line_event.wait(timeout=remaining)
-
-    def close(self):
-        if self.process and self.process.returncode is None:
-            self.process.terminate()
-            try:
-                self.process.wait(timeout=PROCESS_TERMINATE_TIMEOUT)
-            except subprocess.TimeoutExpired:
-                self.process.kill()
-                self.process.wait(timeout=PROCESS_TERMINATE_TIMEOUT)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close()
-
-    def _read_output(self):
-        """Read stdout in background thread."""
-        stdout = self.process.stdout if self.process else None
-        if stdout is None:
-            self._closed = True
-            self._line_event.set()
-            return
-        try:
-            for line in stdout:
-                with self._lock:
-                    self._output.append(line)
-                self._line_event.set()
-        finally:
-            self._closed = True
-            self._line_event.set()
-
-
-def default_binary_args(config: pytest.Config, *extra: str) -> list[str]:
-    """Build binary args: ephemeral-port URL plus extras and any --opensovd-args.
-
-    Skips the auto-injected --url if the caller (or --opensovd-args) already
-    supplied one. Detects both `--url X` and `--url=X` forms.
-    """
-    extra_args = shlex.split(config.getoption("--opensovd-args"))
-    has_url = any(a == "--url" or a.startswith("--url=") for a in (*extra, *extra_args))
-    if has_url:
-        return [*extra, *extra_args]
-    return ["--url", "http://127.0.0.1:0/sovd", *extra, *extra_args]
-
-
-def spawn_process(
-    config: pytest.Config,
-    args: list[str],
-    ready_banner: re.Pattern | None = None,
-    crate: str = "opensovd-gateway",
-) -> ProcessUnderTest:
-    """Spawn the process under test with the given arguments.
-
-    This is a helper for tests that need custom configurations.
-    For standard tests, use the module-scoped `gateway` fixture instead.
-
-    Args:
-        config: pytest configuration object
-        args: Command-line arguments to pass after the run command / binary
-        ready_banner: Pattern to wait for before considering ready (None to
-            skip). The match (groups: addr, transport, base) is stored on
-            ProcessUnderTest.match for SovdClient to interpret.
-        crate: cargo workspace package name to build when --opensovd-run is unset
-
-    Returns:
-        A running ProcessUnderTest instance (caller must call close())
-    """
-    run_cmd = config.getoption("--opensovd-run")
-    if run_cmd:
-        cmd = [*shlex.split(run_cmd), *args]
-    else:
-        bin_path = _build_crate_binary(config, crate)
-        cmd = [str(bin_path), *args]
-    return ProcessUnderTest.spawn(cmd, ready_banner=ready_banner)
 
 
 def listening_url(match: re.Match) -> str:
@@ -287,3 +26,16 @@ def listening_url(match: re.Match) -> str:
     if transport == "tls":
         return f"https://{addr}{base}"
     return f"http://localhost{base}"
+
+
+def default_binary_args(config: pytest.Config, *extra: str) -> list[str]:
+    """Build binary args: ephemeral-port URL plus extras and any --opensovd-args.
+
+    Skips the auto-injected --url if the caller (or --opensovd-args) already
+    supplied one. Detects both `--url X` and `--url=X` forms.
+    """
+    extra_args = shlex.split(config.getoption("--opensovd-args"))
+    has_url = any(a == "--url" or a.startswith("--url=") for a in (*extra, *extra_args))
+    if has_url:
+        return [*extra, *extra_args]
+    return ["--url", "http://127.0.0.1:0/sovd", *extra, *extra_args]

--- a/tests/opensovd-gateway/conftest.py
+++ b/tests/opensovd-gateway/conftest.py
@@ -7,7 +7,8 @@ from typing import Self
 
 import httpx
 import pytest
-from fixtures import LISTENING_PATTERN, ProcessUnderTest, listening_url, spawn_process
+from fixtures import LISTENING_PATTERN, listening_url
+from opensovd_e2e import ProcessUnderTest, spawn_process
 
 
 class SovdClient:
@@ -109,7 +110,7 @@ def ready_banner():
 @pytest.fixture(scope="module")
 def gateway(
     request,
-    crate_bin,
+    crate_binary,
     binary_args,
     ready_banner,
 ):
@@ -117,7 +118,7 @@ def gateway(
         request.config,
         binary_args,
         ready_banner,
-        crate=crate_bin,
+        crate=crate_binary,
     )
     yield proc
     proc.close()

--- a/tests/opensovd-gateway/test_signals.py
+++ b/tests/opensovd-gateway/test_signals.py
@@ -7,7 +7,8 @@ import signal
 import sys
 
 import pytest
-from fixtures import LISTENING_PATTERN, default_binary_args, spawn_process
+from fixtures import LISTENING_PATTERN, default_binary_args
+from opensovd_e2e import spawn_process
 
 pytestmark = pytest.mark.skipif(
     sys.platform == "win32", reason="Unix signals not supported on Windows"
@@ -18,9 +19,11 @@ SHUTDOWN_SIGNALS = [(signal.SIGINT, "SIGINT"), (signal.SIGTERM, "SIGTERM")]
 
 
 @pytest.fixture
-def gateway(request):
+def gateway(request, crate_binary):
     """Function-scoped gateway for signal testing (will be terminated)."""
-    proc = spawn_process(request.config, default_binary_args(request.config), LISTENING_PATTERN)
+    proc = spawn_process(
+        request.config, default_binary_args(request.config), LISTENING_PATTERN, crate=crate_binary
+    )
     yield proc
     proc.close()
 

--- a/tests/opensovd-mcp/conftest.py
+++ b/tests/opensovd-mcp/conftest.py
@@ -8,20 +8,20 @@ ready-banner plumbing of the generic harness is disabled.
 """
 
 import pytest
-from fixtures import spawn_process
+from opensovd_e2e import spawn_process
 
 
 @pytest.fixture(scope="module")
-def crate_bin() -> str:
+def crate_binary() -> str:
     return "opensovd-mcp"
 
 
 @pytest.fixture(scope="module")
-def mcp(request, crate_bin, binary_args):
+def mcp(request, crate_binary, binary_args):
     proc = spawn_process(
         request.config,
         binary_args,
-        crate=crate_bin,
+        crate=crate_binary,
     )
     yield proc
     proc.close()


### PR DESCRIPTION
## Summary

The pytest e2e harness was inlined under `tests/` and not shareable. This
extracts it into a standalone, auto-loading plugin package (`opensovd-e2e/`) so
any  repo can re-use it.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related

Closes #80
