### PR TITLE
feat(client): SOVD version discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,6 +1129,7 @@ dependencies = [
  "hyper",
  "libcli",
  "opensovd-client",
+ "serde_json",
  "tokio",
  "tower-http",
  "tracing",

--- a/examples/client/Cargo.toml
+++ b/examples/client/Cargo.toml
@@ -20,6 +20,7 @@ http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["http1"] }
 libcli = { workspace = true }
 opensovd-client = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["net", "rt", "macros", "signal"] }
 tower-http = { workspace = true, features = ["trace"] }
 tracing = { workspace = true }

--- a/examples/client/src/client.rs
+++ b/examples/client/src/client.rs
@@ -5,21 +5,24 @@
 
 //! CLI client example exercising the `opensovd-client` API.
 //!
-//! Connects to a running gateway and fetches version info, components,
-//! data items, apps, and areas.
+//! Connects to a running gateway, discovers the advertised SOVD versions via
+//! `/version-info`, and for every found version prints its metadata and lists
+//! its components, data items, apps, and areas.
+//!
+//! `--url` is the unversioned discovery root in every mode.
 //!
 //! ```text
 //! # TCP (default)
 //! cargo run --example client
 //!
 //! # Custom URL
-//! cargo run --example client -- --url http://host:8080/sovd/v1
+//! cargo run --example client -- --url http://host:8080/sovd
 //!
 //! # Unix socket (filesystem path)
-//! cargo run --example client -- --unix-socket /tmp/opensovd.sock --url http://localhost/sovd/v1
+//! cargo run --example client -- --unix-socket /tmp/opensovd.sock --url http://localhost/sovd
 //!
 //! # Abstract Unix socket
-//! cargo run --example client -- --unix-socket @opensovd --url http://localhost/sovd/v1
+//! cargo run --example client -- --unix-socket @opensovd --url http://localhost/sovd
 //! ```
 
 use std::time::Duration;
@@ -28,7 +31,7 @@ use bytes::Bytes;
 use clap::Parser;
 use http::{HeaderMap, Request, Response};
 use http_body_util::Full;
-use opensovd_client::Client;
+use opensovd_client::{Client, Discovery, SovdInfo};
 use tower_http::classify::ServerErrorsFailureClass;
 use tower_http::trace::TraceLayer;
 use tracing::Span;
@@ -38,18 +41,19 @@ use tracing::Span;
 #[command(about = "OpenSOVD client example")]
 #[command(after_help = "\
 Examples:
-  # Connect over TCP (default)
-  client --url http://localhost:7690/sovd/v1
+  # Discover versions over TCP (default)
+  client --url http://localhost:7690/sovd
 
-  # Connect over a Unix socket (filesystem path)
-  client --unix-socket /tmp/opensovd.sock --url http://localhost/sovd/v1
+  # Discover over a Unix socket (filesystem path)
+  client --unix-socket /tmp/opensovd.sock --url http://localhost/sovd
 
-  # Connect over an abstract Unix socket
-  client --unix-socket @opensovd --url http://localhost/sovd/v1
+  # Discover over an abstract Unix socket
+  client --unix-socket @opensovd --url http://localhost/sovd
 ")]
 struct Cli {
-    /// Base URL of the SOVD server (including version prefix).
-    #[arg(long, default_value = "http://localhost:7690/sovd/v1")]
+    /// SOVD `accessurl`: root of the SOVD API, parent of `version-info` (no version
+    /// identifier). `/version-info` is fetched from it to enumerate supported versions.
+    #[arg(long, default_value = "http://localhost:7690/sovd")]
     url: String,
 
     /// Path to a Unix socket to connect to. Use '@' prefix for abstract sockets.
@@ -90,6 +94,30 @@ async fn run(client: &Client) -> Result<(), opensovd_client::Error> {
     Ok(())
 }
 
+/// Print each advertised version's metadata and run the exercises against its client.
+async fn discover_and_run(discovery: &Discovery) -> Result<(), opensovd_client::Error> {
+    // Value vendor payload so any server's vendor_info shape prints.
+    let versions = discovery.versions::<serde_json::Value>().await?;
+    println!("found {} version(s)", versions.len());
+
+    for v in &versions {
+        let vendor = v.vendor_info.as_ref().map_or_else(
+            || "none".to_string(),
+            |info| serde_json::to_string_pretty(info).unwrap_or_else(|_| "<unprintable>".into()),
+        );
+        println!("version {}", v.version);
+        println!("  base_uri: {}", v.base_uri.0);
+        println!("  vendor_info: {vendor}");
+
+        let client = discovery
+            .select(|s: &SovdInfo<serde_json::Value>| s.version == v.version)
+            .await?;
+        run(&client).await?;
+    }
+
+    Ok(())
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     drop(libcli::init_tracing("info", None));
@@ -100,8 +128,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         if let Some(name) = socket.strip_prefix('@') {
             #[cfg(target_os = "linux")]
             {
-                let client = Client::connect_unix_abstract(&cli.url, name)?;
-                run(&client).await?;
+                let discovery = Discovery::connect_unix_abstract(&cli.url, name)?;
+                discover_and_run(&discovery).await?;
                 return Ok(());
             }
             #[cfg(not(target_os = "linux"))]
@@ -110,12 +138,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 return Err("abstract Unix sockets are only supported on Linux".into());
             }
         }
-        let client = Client::connect_unix(&cli.url, socket)?;
-        run(&client).await?;
+        let discovery = Discovery::connect_unix(&cli.url, socket)?;
+        discover_and_run(&discovery).await?;
         return Ok(());
     }
 
-    let client = Client::builder()
+    let discovery = Client::builder()
         .base_uri(&cli.url)?
         .layer(
             TraceLayer::new_for_http()
@@ -162,7 +190,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     },
                 ),
         )
-        .build()?;
-    run(&client).await?;
+        .discovery()?;
+    discover_and_run(&discovery).await?;
     Ok(())
 }

--- a/opensovd-client/Cargo.toml
+++ b/opensovd-client/Cargo.toml
@@ -25,6 +25,7 @@ serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
 tower = { workspace = true, features = ["util"] }
+tokio = { workspace = true, features = ["sync"] }
 
 [target.'cfg(unix)'.dependencies]
 tokio = { workspace = true, features = ["net"] }

--- a/opensovd-client/README.md
+++ b/opensovd-client/README.md
@@ -1,0 +1,43 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# opensovd-client
+
+> Async HTTP client for the SOVD (ISO 17978-3) API.
+
+- `Client` is bound to a single SOVD API version: it targets a version-specific
+  `base_uri` and exposes the resources (components, apps, areas, data).
+- `Discovery` is the version-agnostic entry point: built from the server root, it
+  reads the unversioned `version-info` endpoint, lists the advertised versions, and
+  hands you a `Client` for one of them, reusing the same transport (custom connector,
+  TLS, tower layers).
+
+## Usage
+
+```rust,no_run
+use opensovd_client::{Client, SovdInfo, VendorInfo};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+// Point at the SOVD server root (no version identifier).
+let discovery = Client::builder()
+    .base_uri("http://localhost:7690/sovd")?
+    .discovery()?;
+
+// See what the server advertises.
+for info in discovery.versions::<VendorInfo>().await? {
+    println!("{} -> {}", info.version, info.base_uri.0);
+}
+
+// Select a version and exercise it (or match on `vendor_info` via the `V` payload).
+let client = discovery.select(|s: &SovdInfo<VendorInfo>| s.version == "1.1").await?;
+for c in &client.list_components().send().await?.data.items {
+    println!("component: {} ({})", c.id, c.name);
+}
+# Ok(())
+# }
+```
+
+On Unix, `Discovery::connect_unix` / `connect_unix_abstract` reach `version-info`
+over a Unix domain socket. A runnable example lives in `examples/client`.
+
+Part of [OpenSOVD Core](https://github.com/eclipse-opensovd/opensovd-core).

--- a/opensovd-client/src/client.rs
+++ b/opensovd-client/src/client.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use bytes::Bytes;
 use http_body::Body;
 use http_body_util::{BodyExt, Full, combinators::BoxBody};
@@ -10,12 +12,14 @@ use hyper_util::{
 };
 use serde::{Serialize, de::DeserializeOwned};
 use thiserror::Error;
+use tokio::sync::OnceCell;
 use tower::{
     Layer, Service,
     layer::util::{Identity, Stack},
     util::{BoxCloneSyncService, MapErrLayer, MapResponseLayer},
 };
 
+use crate::discovery::Discovery;
 use crate::entities::{App, Area, Component};
 use crate::error::{Error, Result};
 use crate::list::ListEntitiesRequest;
@@ -101,7 +105,7 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
     ///
     /// # Errors
     ///
-    /// Returns an error if the base URI has not been set.
+    /// Returns [`BuilderError::NoBaseUri`] if the base URI has not been set.
     pub fn build<ResBody>(self) -> std::result::Result<Client, BuilderError>
     where
         Conn: hyper_util::client::legacy::connect::Connect + Clone + Send + Sync + 'static,
@@ -131,6 +135,36 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
             http: BoxCloneSyncService::new(service),
         })
     }
+
+    /// Build a [`Discovery`] client for the unversioned `/version-info` endpoint, reusing this
+    /// builder's transport.
+    ///
+    /// The base URI must be the unversioned SOVD root (no version identifier), e.g.
+    /// `http://localhost:7690/sovd`. Select a version on the returned [`Discovery`] to reach a
+    /// [`Client`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BuilderError::NoBaseUri`] if the base URI has not been set.
+    pub fn discovery<ResBody>(self) -> std::result::Result<Discovery, BuilderError>
+    where
+        Conn: hyper_util::client::legacy::connect::Connect + Clone + Send + Sync + 'static,
+        Layers: Layer<legacy::Client<Conn, Full<Bytes>>> + Clone + Send + Sync + 'static,
+        Layers::Service: Service<http::Request<Full<Bytes>>, Response = http::Response<ResBody>>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+        <Layers::Service as Service<http::Request<Full<Bytes>>>>::Future: Send,
+        <Layers::Service as Service<http::Request<Full<Bytes>>>>::Error: Into<BoxError>,
+        ResBody: Body<Data = Bytes> + Send + Sync + 'static,
+        ResBody::Error: Into<BoxError>,
+    {
+        Ok(Discovery {
+            inner: self.build()?,
+            cache: Arc::new(OnceCell::new()),
+        })
+    }
 }
 
 /// SOVD REST client with a type-erased HTTP transport.
@@ -153,7 +187,7 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns an error if the URI is invalid.
+    /// Returns [`BuilderError::InvalidUri`] if the URI is invalid.
     pub fn connect(uri: &str) -> std::result::Result<Self, BuilderError> {
         Self::builder().base_uri(uri)?.build()
     }
@@ -279,7 +313,7 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns an error if the URI is invalid.
+    /// Returns [`BuilderError::InvalidUri`] if the URI is invalid.
     pub fn connect_unix(
         uri: &str,
         path: impl AsRef<std::path::Path>,
@@ -296,7 +330,7 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns an error if the URI is invalid.
+    /// Returns [`BuilderError::InvalidUri`] if the URI is invalid.
     #[cfg(target_os = "linux")]
     pub fn connect_unix_abstract(
         uri: &str,
@@ -328,7 +362,13 @@ pub(crate) fn build_uri_with_query(
     path: &str,
     query: &[(&str, &str)],
 ) -> Result<http::Uri> {
-    let base = format!("{base_uri}{path}");
+    // A root base URI such as `http://localhost` renders with a trailing slash;
+    // avoid a doubled slash when the path also starts with one.
+    let mut base = base_uri.to_string();
+    if path.starts_with('/') && base.ends_with('/') {
+        base.pop();
+    }
+    base.push_str(path);
     Ok(build_uri_query_string(&base, query).parse()?)
 }
 

--- a/opensovd-client/src/discovery.rs
+++ b/opensovd-client/src/discovery.rs
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use opensovd_models::version::{SovdInfo, VersionInfo};
+use serde::de::DeserializeOwned;
+use tokio::sync::OnceCell;
+
+#[cfg(unix)]
+use crate::client::BuilderError;
+use crate::client::Client;
+use crate::error::{Error, Result};
+
+/// Client for the unversioned SOVD `/version-info` endpoint.
+///
+/// Built via [`ClientBuilder::discovery`](crate::ClientBuilder::discovery); select a version
+/// to reach a [`Client`]. Cheap to clone; clones share one cached `/version-info` fetch.
+#[derive(Clone)]
+pub struct Discovery {
+    /// Rooted client carrying the transport (connector and layers).
+    pub(crate) inner: Client,
+    /// Cached `/version-info` body, shared across clones. Vendor metadata kept as raw
+    /// `Value` so one cache serves any concrete `V`.
+    pub(crate) cache: Arc<OnceCell<VersionInfo<serde_json::Value>>>,
+}
+
+impl Discovery {
+    /// List the advertised SOVD instances.
+    ///
+    /// The first call fetches `/version-info`; later calls reuse the cached response.
+    /// `V` is the `vendor_info` payload type
+    /// ([`VendorInfo`](opensovd_models::version::VendorInfo) for the default shape).
+    #[allow(clippy::result_large_err)]
+    pub async fn versions<V: DeserializeOwned>(&self) -> Result<Vec<SovdInfo<V>>> {
+        let info = self
+            .cache
+            .get_or_try_init(|| {
+                self.inner
+                    .get::<VersionInfo<serde_json::Value>>("/version-info", &[])
+            })
+            .await?;
+        // Re-type vendor_info from the cached raw Value into the requested V.
+        info.sovd_info
+            .iter()
+            .map(|s| {
+                Ok(SovdInfo {
+                    version: s.version.clone(),
+                    base_uri: s.base_uri.clone(),
+                    vendor_info: s
+                        .vendor_info
+                        .clone()
+                        .map(serde_json::from_value)
+                        .transpose()?,
+                })
+            })
+            .collect()
+    }
+
+    /// Select the first advertised instance matching `pred` and return a ready, versioned
+    /// [`Client`] that reuses this transport.
+    ///
+    /// Match on `version`, or on typed `vendor_info` by choosing the `V` payload type
+    /// (use `serde_json::Value` when matching on `version` only).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NoMatchingVersion`] if no advertised instance matches.
+    pub async fn select<V: DeserializeOwned>(
+        &self,
+        mut pred: impl FnMut(&SovdInfo<V>) -> bool,
+    ) -> Result<Client> {
+        let advertised = self
+            .versions::<V>()
+            .await?
+            .into_iter()
+            .find(|s| pred(s))
+            .ok_or(Error::NoMatchingVersion)?
+            .base_uri
+            .0;
+        Ok(Client {
+            base_uri: advertised.parse()?,
+            http: self.inner.http.clone(),
+        })
+    }
+}
+
+#[cfg(unix)]
+impl Discovery {
+    /// Build a [`Discovery`] reached over a Unix domain socket (filesystem path).
+    ///
+    /// `uri` is the unversioned discovery root, e.g. `http://localhost/sovd`; its host is
+    /// ignored and all requests are routed to the socket at `path`. Mirrors
+    /// [`Client::connect_unix`](crate::Client::connect_unix), but targets `/version-info`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BuilderError::InvalidUri`] if the URI is invalid.
+    pub fn connect_unix(
+        uri: &str,
+        path: impl AsRef<std::path::Path>,
+    ) -> std::result::Result<Self, BuilderError> {
+        let connector = crate::unix::UnixConnector::new(path);
+        Client::builder()
+            .base_uri(uri)?
+            .connector(connector)
+            .discovery()
+    }
+
+    /// Build a [`Discovery`] reached over a Linux abstract Unix socket.
+    ///
+    /// `name` is the abstract socket name (without a leading null byte); `uri` is the
+    /// unversioned discovery root, e.g. `http://localhost/sovd`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BuilderError::InvalidUri`] if the URI is invalid.
+    #[cfg(target_os = "linux")]
+    pub fn connect_unix_abstract(
+        uri: &str,
+        name: impl AsRef<[u8]>,
+    ) -> std::result::Result<Self, BuilderError> {
+        let connector = crate::unix::UnixConnector::abstract_name(name);
+        Client::builder()
+            .base_uri(uri)?
+            .connector(connector)
+            .discovery()
+    }
+}

--- a/opensovd-client/src/error.rs
+++ b/opensovd-client/src/error.rs
@@ -5,7 +5,12 @@ use opensovd_models::GenericError;
 
 /// Client error type.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
+    /// No advertised SOVD instance matched the selection.
+    #[error("no matching SOVD version")]
+    NoMatchingVersion,
+
     /// Server returned a non-success status code.
     #[error("server error {status}: {error:?}")]
     ApiError {

--- a/opensovd-client/src/lib.rs
+++ b/opensovd-client/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(clippy::missing_errors_doc)]
+#![doc = include_str!("../README.md")]
 
 mod client;
 mod data;

--- a/opensovd-client/src/lib.rs
+++ b/opensovd-client/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod client;
 mod data;
+mod discovery;
 pub mod entities;
 mod error;
 mod list;
@@ -12,5 +13,7 @@ mod list;
 mod unix;
 
 pub use client::{BuilderError, Client, ClientBuilder};
+pub use discovery::Discovery;
 pub use error::{Error, Result};
 pub use opensovd_models::Response;
+pub use opensovd_models::version::{SovdInfo, VendorInfo, VersionInfo};

--- a/opensovd-client/tests/discovery.rs
+++ b/opensovd-client/tests/discovery.rs
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use mock_http_connector::Connector;
+use opensovd_client::{Client, SovdInfo, VendorInfo};
+use serde_json::json;
+
+fn discovery(connector: Connector) -> opensovd_client::Discovery {
+    Client::builder()
+        .base_uri("http://localhost:7690/sovd")
+        .expect("valid URI")
+        .connector(connector)
+        .discovery()
+        .expect("valid discovery client")
+}
+
+#[tokio::test]
+async fn select_reuses_transport() {
+    let mut b = Connector::builder();
+    b.expect()
+        .with_uri("http://localhost:7690/sovd/version-info")
+        .returning(
+            json!({"sovd_info": [{
+                "version": "1.1",
+                "base_uri": "http://localhost:7690/sovd/v1"
+            }]})
+            .to_string(),
+        )
+        .unwrap();
+    b.expect()
+        .with_uri("http://localhost:7690/sovd/v1/components")
+        .returning(json!({"items": []}).to_string())
+        .unwrap();
+
+    let client = discovery(b.build())
+        .select(|s: &SovdInfo<serde_json::Value>| s.version == "1.1")
+        .await
+        .unwrap();
+
+    // The selected client must reuse the same (mock) transport and hit the advertised base.
+    let list = client.list_components().send().await.unwrap();
+    assert!(list.data.items.is_empty());
+}
+
+#[tokio::test]
+async fn select_matches_on_vendor_info() {
+    // Exercises the typed vendor_info predicate path of `select`.
+    let mut b = Connector::builder();
+    b.expect()
+        .with_uri("http://localhost:7690/sovd/version-info")
+        .returning(
+            json!({"sovd_info": [{
+                "version": "1.1",
+                "base_uri": "http://localhost:7690/sovd/v1",
+                "vendor_info": {"name": "OpenSOVD", "version": "2.0"}
+            }]})
+            .to_string(),
+        )
+        .unwrap();
+    b.expect()
+        .with_uri("http://localhost:7690/sovd/v1/components")
+        .returning(json!({"items": []}).to_string())
+        .unwrap();
+
+    let client = discovery(b.build())
+        .select(|s: &SovdInfo<VendorInfo>| {
+            s.vendor_info.as_ref().is_some_and(|v| v.name == "OpenSOVD")
+        })
+        .await
+        .unwrap();
+    assert!(
+        client
+            .list_components()
+            .send()
+            .await
+            .unwrap()
+            .data
+            .items
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn select_no_match() {
+    let mut b = Connector::builder();
+    b.expect()
+        .with_uri("http://localhost:7690/sovd/version-info")
+        .returning(
+            json!({"sovd_info": [{
+                "version": "1.1",
+                "base_uri": "http://localhost:7690/sovd/v1"
+            }]})
+            .to_string(),
+        )
+        .unwrap();
+
+    let err = discovery(b.build())
+        .select(|s: &SovdInfo<serde_json::Value>| s.version == "2.0")
+        .await
+        .err()
+        .expect("expected an error");
+    assert!(
+        matches!(err, opensovd_client::Error::NoMatchingVersion),
+        "expected NoMatchingVersion, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn versions_lists_instances() {
+    let mut b = Connector::builder();
+    b.expect()
+        .with_uri("http://localhost:7690/sovd/version-info")
+        .returning(
+            json!({"sovd_info": [{
+                "version": "1.1",
+                "base_uri": "http://localhost:7690/sovd/v1",
+                "vendor_info": {"name": "OpenSOVD", "version": "2.0"}
+            }]})
+            .to_string(),
+        )
+        .unwrap();
+
+    let versions: Vec<SovdInfo<VendorInfo>> = discovery(b.build()).versions().await.unwrap();
+
+    assert_eq!(versions.len(), 1);
+    assert_eq!(versions[0].version, "1.1");
+    let vendor = versions[0]
+        .vendor_info
+        .as_ref()
+        .expect("vendor info present");
+    assert_eq!(vendor.name, "OpenSOVD");
+    assert_eq!(vendor.version, "2.0");
+}
+
+#[tokio::test]
+async fn versions_without_vendor() {
+    let mut b = Connector::builder();
+    b.expect()
+        .with_uri("http://localhost:7690/sovd/version-info")
+        .returning(
+            json!({"sovd_info": [{
+                "version": "1.1",
+                "base_uri": "http://localhost:7690/sovd/v1"
+            }]})
+            .to_string(),
+        )
+        .unwrap();
+
+    let versions: Vec<SovdInfo<VendorInfo>> = discovery(b.build()).versions().await.unwrap();
+    assert!(versions[0].vendor_info.is_none());
+}
+
+#[tokio::test]
+async fn versions_accepts_arbitrary_vendor() {
+    let mut b = Connector::builder();
+    b.expect()
+        .with_uri("http://localhost:7690/sovd/version-info")
+        .returning(
+            json!({"sovd_info": [{
+                "version": "1.1",
+                "base_uri": "http://localhost:7690/sovd/v1",
+                "vendor_info": {"anything": [1, 2, 3]}
+            }]})
+            .to_string(),
+        )
+        .unwrap();
+
+    let versions: Vec<SovdInfo<serde_json::Value>> = discovery(b.build()).versions().await.unwrap();
+    assert_eq!(versions[0].vendor_info.as_ref().unwrap()["anything"][2], 3);
+}
+
+#[tokio::test]
+async fn version_info_error_status() {
+    let mut b = Connector::builder();
+    b.expect()
+        .with_uri("http://localhost:7690/sovd/version-info")
+        .returning((
+            http::StatusCode::NOT_FOUND,
+            json!({"error_code": "vendor-specific", "message": "not found"}).to_string(),
+        ))
+        .unwrap();
+
+    let err = discovery(b.build())
+        .select(|s: &SovdInfo<serde_json::Value>| s.version == "1.1")
+        .await
+        .err()
+        .expect("expected an error");
+    match err {
+        opensovd_client::Error::ApiError { status, error } => {
+            assert_eq!(status.as_u16(), 404);
+            assert!(error.is_some());
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn version_info_is_cached() {
+    let mut b = Connector::builder();
+    b.expect()
+        .times(1)
+        .with_uri("http://localhost:7690/sovd/version-info")
+        .returning(
+            json!({"sovd_info": [{
+                "version": "1.1",
+                "base_uri": "http://localhost:7690/sovd/v1"
+            }]})
+            .to_string(),
+        )
+        .unwrap();
+    let connector = b.build();
+
+    let disco = discovery(connector.clone());
+    // Two reads of the version list must hit /version-info exactly once.
+    let _ = disco.versions::<VendorInfo>().await.unwrap();
+    let _ = disco
+        .select(|s: &SovdInfo<serde_json::Value>| s.version == "1.1")
+        .await
+        .unwrap();
+
+    connector
+        .checkpoint()
+        .expect("version-info should be fetched exactly once");
+}


### PR DESCRIPTION
## Summary

Add an async SOVD HTTP client with version discovery. `Discovery` reads the
unversioned `version-info` endpoint and selects an advertised version to mint a
versioned `Client` that reuses the same transport (TCP or Unix socket). Ships
with a runnable example and a crate README.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related

Closes #82

