### PR TITLE
chore: dedupe rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
-# SPDX-License-Identifier: Apache-2.0
-
-group_imports = "StdExternalCrate"
-style_edition = "2024"
-max_width = 100

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+unstable_features = true
 newline_style = "Unix"
 group_imports = "StdExternalCrate"
-imports_granularity = "Crate"
 style_edition = "2024"
 max_width = 100


### PR DESCRIPTION
## Summary

Consolidate the duplicated rustfmt configuration into a single root `rustfmt.toml`. 

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests
