### PR TITLE
fix(server): parse repeated data filter query params

### DIFF
--- a/opensovd-server/src/routes/data.rs
+++ b/opensovd-server/src/routes/data.rs
@@ -17,12 +17,12 @@
 
 use axum::{
     Router,
-    extract::{Path, Query, State},
+    extract::{Path, State},
     http::StatusCode,
     response::Json,
     routing::get,
 };
-use axum_extra::extract::WithRejection;
+use axum_extra::extract::{Query, WithRejection};
 use opensovd_core::DataFilter;
 use opensovd_core::Topology;
 use opensovd_models::Response;

--- a/opensovd-server/src/routes/entities/app.rs
+++ b/opensovd-server/src/routes/entities/app.rs
@@ -3,12 +3,12 @@
 
 use axum::{
     Router,
-    extract::{Path, Query, State},
+    extract::{Path, State},
     http::request::Parts,
     response::Json,
     routing::get,
 };
-use axum_extra::extract::WithRejection;
+use axum_extra::extract::{Query, WithRejection};
 use opensovd_core::Topology;
 use opensovd_models::Response;
 use opensovd_models::discovery::{

--- a/opensovd-server/src/routes/entities/area.rs
+++ b/opensovd-server/src/routes/entities/area.rs
@@ -3,12 +3,12 @@
 
 use axum::{
     Router,
-    extract::{Path, Query, State},
+    extract::{Path, State},
     http::request::Parts,
     response::Json,
     routing::get,
 };
-use axum_extra::extract::WithRejection;
+use axum_extra::extract::{Query, WithRejection};
 use opensovd_core::Topology;
 use opensovd_models::Response;
 use opensovd_models::discovery::{

--- a/opensovd-server/src/routes/entities/component.rs
+++ b/opensovd-server/src/routes/entities/component.rs
@@ -3,12 +3,12 @@
 
 use axum::{
     Router,
-    extract::{Path, Query, State},
+    extract::{Path, State},
     http::request::Parts,
     response::Json,
     routing::get,
 };
-use axum_extra::extract::WithRejection;
+use axum_extra::extract::{Query, WithRejection};
 use opensovd_core::Topology;
 use opensovd_models::Response;
 use opensovd_models::discovery::{

--- a/opensovd-server/src/routes/entities/mod.rs
+++ b/opensovd-server/src/routes/entities/mod.rs
@@ -21,14 +21,8 @@ mod app;
 mod area;
 mod component;
 
-use axum::{
-    Router,
-    extract::{Query, State},
-    http::request::Parts,
-    response::Json,
-    routing::get,
-};
-use axum_extra::extract::WithRejection;
+use axum::{Router, extract::State, http::request::Parts, response::Json, routing::get};
+use axum_extra::extract::{Query, WithRejection};
 use opensovd_core::Topology;
 use opensovd_models::Response;
 use opensovd_models::discovery::{EntityCapabilities, EntityCapabilitiesQuery};

--- a/opensovd-server/src/routes/error.rs
+++ b/opensovd-server/src/routes/error.rs
@@ -6,10 +6,10 @@
 //! Defines error types that convert to SOVD-compliant HTTP error responses.
 
 use axum::{
-    extract::rejection::QueryRejection,
     http::StatusCode,
     response::{IntoResponse, Json, Response},
 };
+use axum_extra::extract::QueryRejection;
 use opensovd_core::{DataError, TopologyError};
 use opensovd_models::{ErrorCode, GenericError};
 
@@ -170,8 +170,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_error_bad_query() {
-        use axum::{Router, body::Body, extract::Query, http::Request, routing::get};
-        use axum_extra::extract::WithRejection;
+        use axum::{Router, body::Body, http::Request, routing::get};
+        use axum_extra::extract::{Query, WithRejection};
         use serde::Deserialize;
         use tower::ServiceExt;
 

--- a/opensovd-server/src/routes/version.rs
+++ b/opensovd-server/src/routes/version.rs
@@ -6,14 +6,8 @@
 //! Provides routes for:
 //! - GET /version-info - Get SOVD server version and vendor information
 
-use axum::{
-    Router,
-    extract::{Query, State},
-    http::request::Parts,
-    response::Json,
-    routing::get,
-};
-use axum_extra::extract::WithRejection;
+use axum::{Router, extract::State, http::request::Parts, response::Json, routing::get};
+use axum_extra::extract::{Query, WithRejection};
 use opensovd_models::Response;
 use opensovd_models::version::{SovdInfo, VersionInfo, VersionInfoQuery};
 use serde::Serialize;

--- a/opensovd-server/tests/data_filter.rs
+++ b/opensovd-server/tests/data_filter.rs
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! End-to-end coverage for the SOVD data filter on the data list endpoint.
+//!
+//! The filter (`groups`, `categories`, `tags`) is sent as repeated query
+//! parameters per ISO 17978-3 (form style, explode=true). These tests pin
+//! that the server parses that wire format into the `DataFilter` the provider
+//! receives, and that a malformed query still rejects cleanly.
+
+mod common;
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use http_body_util::BodyExt;
+use hyper::Request;
+use opensovd_core::{Component, Data, DataError, DataFilter, DataProvider, Metadata, Topology};
+
+/// A data provider that records the last filter it was asked to list with.
+#[derive(Clone)]
+struct RecordingProvider {
+    seen: Arc<Mutex<Option<DataFilter>>>,
+}
+
+#[async_trait]
+impl DataProvider for RecordingProvider {
+    async fn list(&self, filter: DataFilter) -> Result<Vec<Metadata>, DataError> {
+        *self.seen.lock().unwrap() = Some(filter);
+        Ok(Vec::new())
+    }
+
+    async fn read(&self, data_id: &str, _include_schema: bool) -> Result<Data, DataError> {
+        Err(DataError::NotFound(data_id.into()))
+    }
+
+    async fn write(&self, _data_id: &str, _value: serde_json::Value) -> Result<(), DataError> {
+        Err(DataError::ReadOnly)
+    }
+}
+
+async fn server_with_recorder() -> (common::TestServer, Arc<Mutex<Option<DataFilter>>>) {
+    let seen = Arc::new(Mutex::new(None));
+    let provider = RecordingProvider {
+        seen: Arc::clone(&seen),
+    };
+    let topology = Topology::new();
+    topology
+        .write()
+        .await
+        .add_component(Component::new("ECU", "Engine Control Unit").with_data_provider(provider));
+    let server = common::TestServer::builder()
+        .topology(topology)
+        .build()
+        .await;
+    (server, seen)
+}
+
+#[tokio::test]
+async fn data_list_parses_repeated_filter_keys() {
+    let (server, seen) = server_with_recorder().await;
+    let client = common::client();
+
+    let request = Request::builder()
+        .uri(server.url(
+            "/sovd/v1/components/ECU/data\
+             ?groups=sensors&groups=actuators\
+             &categories=currentData&categories=x-custom\
+             &tags=OBD&tags=ePTI",
+        ))
+        .body(http_body_util::Empty::<bytes::Bytes>::new())
+        .unwrap();
+
+    let response = client.request(request).await.unwrap();
+    assert!(response.status().is_success(), "got {}", response.status());
+
+    let filter = seen.lock().unwrap().clone().expect("provider was listed");
+    assert_eq!(filter.groups, vec!["sensors", "actuators"]);
+    assert_eq!(filter.categories, vec!["currentData", "x-custom"]);
+    assert_eq!(filter.tags, vec!["OBD", "ePTI"]);
+}
+
+#[tokio::test]
+async fn data_list_without_filter_is_empty() {
+    let (server, seen) = server_with_recorder().await;
+    let client = common::client();
+
+    let request = Request::builder()
+        .uri(server.url("/sovd/v1/components/ECU/data"))
+        .body(http_body_util::Empty::<bytes::Bytes>::new())
+        .unwrap();
+
+    let response = client.request(request).await.unwrap();
+    assert!(response.status().is_success());
+
+    let filter = seen.lock().unwrap().clone().expect("provider was listed");
+    assert!(filter.groups.is_empty());
+    assert!(filter.categories.is_empty());
+    assert!(filter.tags.is_empty());
+}
+
+#[tokio::test]
+async fn data_list_rejects_malformed_query() {
+    let (server, _seen) = server_with_recorder().await;
+    let client = common::client();
+
+    // include-schema expects a bool; a non-bool value must 400.
+    let request = Request::builder()
+        .uri(server.url("/sovd/v1/components/ECU/data?include-schema=maybe"))
+        .body(http_body_util::Empty::<bytes::Bytes>::new())
+        .unwrap();
+
+    let response = client.request(request).await.unwrap();
+    assert_eq!(response.status(), 400);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error_code"], "incomplete-request");
+}

--- a/tests/opensovd-gateway/mocks/conftest.py
+++ b/tests/opensovd-gateway/mocks/conftest.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared fixtures for tests that run the gateway with mock entities."""
+
+import pytest
+from fixtures import default_binary_args
+
+
+@pytest.fixture(scope="module")
+def binary_args(request):
+    """Enable mock entities for all tests in this directory."""
+    return default_binary_args(request.config, "--mock")

--- a/tests/opensovd-gateway/mocks/test_data_filter.py
+++ b/tests/opensovd-gateway/mocks/test_data_filter.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the data filter on the data list endpoint."""
+
+import pytest
+
+DATA = "/v1/components/ecu/data"
+ALL = {
+    "voltage",
+    "temperature",
+    "sw.version",
+    "sw.build_date",
+    "sw.sha1",
+    "hw.version",
+    "hw.revision",
+    "hw.sn",
+}
+IDENT = {"sw.version", "sw.build_date", "sw.sha1", "hw.version", "hw.revision", "hw.sn"}
+CURRENT = {"voltage", "temperature"}
+
+
+# The mock provider applies filters as AND across dimensions, OR within each.
+@pytest.mark.parametrize(
+    ("params", "expected"),
+    [
+        (None, ALL),
+        ({"categories": "currentData"}, CURRENT),
+        ({"categories": "identData"}, IDENT),
+        ({"groups": "power"}, {"voltage"}),
+        ({"groups": ["power", "thermal"]}, CURRENT),
+        ({"tags": "sensor"}, CURRENT),
+        ({"categories": "currentData", "tags": "sensor"}, CURRENT),
+        ({"categories": "identData", "tags": "sensor"}, set()),
+        ({"groups": "nonexistent"}, set()),
+    ],
+)
+def test_data_list_filter(client, params, expected):
+    """Test that groups/categories/tags narrow the data list."""
+    response = client.get(DATA, params=params)
+    assert response.status_code == 200
+    ids = {item["id"] for item in response.json()["items"]}
+    assert ids == expected


### PR DESCRIPTION
## Summary
The data list endpoint silently dropped `groups`/`categories`/`tags` filters: `axum::extract::Query` (serde_urlencoded) cannot deserialize repeated query keys into a `Vec`. Switch every query call site to `axum_extra::extract::Query` (serde_html_form), with the matching `QueryRejection`, so form-style/explode params parse.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated tests

