### PR TITLE
fix(gateway): guard wildcard CORS methods and add error context

### DIFF
--- a/opensovd-cli/gateway/src/cors.rs
+++ b/opensovd-cli/gateway/src/cors.rs
@@ -12,7 +12,7 @@ use tower_http::cors::{self, CorsLayer};
 /// # Errors
 ///
 /// Returns an error if any origin, method, or header string is invalid,
-/// or if credentials are enabled with wildcard origins or headers.
+/// or if credentials are enabled with wildcard origins, methods, or headers.
 pub fn create_cors_layer(
     origins: &[String],
     methods: &[String],
@@ -25,11 +25,15 @@ pub fn create_cors_layer(
     }
 
     let wildcard_origins = origins.iter().any(|v| v == "*");
+    let wildcard_methods = methods.iter().any(|v| v == "*");
     let wildcard_headers = headers.iter().any(|v| v == "*");
 
     if credentials {
         if wildcard_origins {
             return Err("cannot use wildcard '*' for origins when credentials are enabled".into());
+        }
+        if wildcard_methods {
+            return Err("cannot use wildcard '*' for methods when credentials are enabled".into());
         }
         if wildcard_headers {
             return Err("cannot use wildcard '*' for headers when credentials are enabled".into());
@@ -48,7 +52,7 @@ pub fn create_cors_layer(
         layer.allow_origin(parsed)
     };
 
-    layer = if methods.iter().any(|v| v == "*") {
+    layer = if wildcard_methods {
         layer.allow_methods(cors::Any)
     } else {
         let parsed: Vec<http::Method> = methods
@@ -99,6 +103,13 @@ mod tests {
     fn test_credentials_with_wildcard_origin_fails() {
         let err = create_cors_layer(&[s("*")], &[], &[], true, None).unwrap_err();
         assert!(err.contains("origins"));
+    }
+
+    #[test]
+    fn test_credentials_with_wildcard_method_fails() {
+        let err =
+            create_cors_layer(&[s("http://example.com")], &[s("*")], &[], true, None).unwrap_err();
+        assert!(err.contains("methods"));
     }
 
     #[test]

--- a/opensovd-cli/gateway/src/main.rs
+++ b/opensovd-cli/gateway/src/main.rs
@@ -9,6 +9,7 @@ mod serve_dir;
 
 use std::process::ExitCode;
 
+use anyhow::Context;
 use base64::Engine;
 use clap::Parser;
 use opensovd_core::Topology;
@@ -84,8 +85,11 @@ fn create_jwt_authenticator(
     let algo: JwtAlgorithm = auth
         .jwt_algo
         .parse()
-        .map_err(|e: String| anyhow::anyhow!(e))?;
-    let key = base64::engine::general_purpose::STANDARD.decode(secret)?;
+        .map_err(|e: String| anyhow::anyhow!(e))
+        .with_context(|| format!("invalid --auth-jwt-algo {:?}", auth.jwt_algo))?;
+    let key = base64::engine::general_purpose::STANDARD
+        .decode(secret)
+        .context("--auth-jwt-secret must be base64-encoded")?;
     let issuer = std::mem::take(&mut auth.jwt_issuer);
 
     tracing::info!(target: TARGET, %algo, %issuer, "JWT authentication enabled");
@@ -97,7 +101,8 @@ fn create_rego_authorizer(auth: &mut cli::AuthArgs) -> anyhow::Result<RegorusAut
     let policy_data = std::mem::take(&mut auth.policy_data);
 
     let authorizer = RegorusAuthorizer::from_paths(&policies, &policy_data)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+        .map_err(anyhow::Error::from_boxed)
+        .context("failed to load Rego authorization policies")?;
     tracing::info!(target: TARGET, count = policies.len(), "Rego policy authorization enabled");
     Ok(authorizer)
 }
@@ -111,7 +116,10 @@ where
     Authn: Authenticator,
     Authz: Authorizer<Authn::Identity>,
 {
-    let uri: http::Uri = cli.url.parse()?;
+    let uri: http::Uri = cli
+        .url
+        .parse()
+        .with_context(|| format!("invalid --url {:?}", cli.url))?;
     let base_uri = uri.path();
     let authority = uri
         .authority()
@@ -198,21 +206,29 @@ async fn configure_listener<Vendor, Authn, Authz, Layer>(
         #[cfg(target_os = "linux")]
         let listener = if let Some(name) = socket_path.strip_prefix('@') {
             use std::os::linux::net::SocketAddrExt;
-            let addr = std::os::unix::net::SocketAddr::from_abstract_name(name)?;
-            let std_listener = std::os::unix::net::UnixListener::bind_addr(&addr)?;
+            let addr =
+                std::os::unix::net::SocketAddr::from_abstract_name(name).with_context(|| {
+                    format!("invalid abstract socket name in --unix-socket {socket_path}")
+                })?;
+            let std_listener = std::os::unix::net::UnixListener::bind_addr(&addr)
+                .with_context(|| format!("failed to bind abstract unix socket {socket_path}"))?;
             std_listener.set_nonblocking(true)?;
             UnixListener::from_std(std_listener)?
         } else {
-            UnixListener::bind(socket_path)?
+            UnixListener::bind(socket_path)
+                .with_context(|| format!("failed to bind unix socket {socket_path}"))?
         };
 
         #[cfg(not(target_os = "linux"))]
-        let listener = UnixListener::bind(socket_path)?;
+        let listener = UnixListener::bind(socket_path)
+            .with_context(|| format!("failed to bind unix socket {socket_path}"))?;
 
         return Ok(builder.listener(listener));
     }
 
-    let listener = tokio::net::TcpListener::bind(authority).await?;
+    let listener = tokio::net::TcpListener::bind(authority)
+        .await
+        .with_context(|| format!("failed to bind {authority}"))?;
     Ok(builder.listener(listener))
 }
 
@@ -222,7 +238,9 @@ async fn configure_listener<Vendor, Authn, Authz, Layer>(
     _cli: &cli::Cli,
     authority: &str,
 ) -> anyhow::Result<opensovd_server::ServerBuilder<Vendor, Authn, Authz, Layer>> {
-    let listener = tokio::net::TcpListener::bind(authority).await?;
+    let listener = tokio::net::TcpListener::bind(authority)
+        .await
+        .with_context(|| format!("failed to bind {authority}"))?;
     Ok(builder.listener(listener))
 }
 

--- a/opensovd-extra/src/auth/rego.rs
+++ b/opensovd-extra/src/auth/rego.rs
@@ -59,7 +59,7 @@ impl RegorusAuthorizer {
     pub fn from_paths(
         policies: &[impl AsRef<Path>],
         data: &[impl AsRef<Path>],
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let mut engine = Engine::new();
 
         for (i, path) in policies.iter().enumerate() {


### PR DESCRIPTION
## Summary

Two related fixes to gateway startu:

- **Reject `--cors-method '*'` with `--cors-credentials`.** tower-http asserts this at layer-build time, so the old config passed validation then panicked at startup; it now fails fast with a clear CLI error.
- **Add anyhow context to the startup failure paths** (JWT secret/algo, `--url`, Rego policy load, TCP and Unix socket binds) so errors name the offending flag/address while preserving the root cause in the `Caused by:` chain.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated tests
