### PR TITLE
fix(server): align data resource collection filtering with the SOVD spec

### DIFF
--- a/opensovd-core/src/data.rs
+++ b/opensovd-core/src/data.rs
@@ -5,11 +5,17 @@
 
 use async_trait::async_trait;
 
+/// The mutually-exclusive scope of a data resource query: groups or categories.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DataScope {
+    Groups(Vec<String>),
+    Categories(Vec<String>),
+}
+
 /// Filter criteria for listing data values.
 #[derive(Debug, Clone, Default)]
 pub struct DataFilter {
-    pub groups: Vec<String>,
-    pub categories: Vec<String>,
+    pub scope: Option<DataScope>,
     pub tags: Vec<String>,
 }
 

--- a/opensovd-core/src/lib.rs
+++ b/opensovd-core/src/lib.rs
@@ -11,7 +11,8 @@ mod entity;
 mod topology;
 
 pub use data::{
-    CategoryInfo, Data, DataError, DataFilter, DataProvider, GroupInfo, Metadata, TagInfo,
+    CategoryInfo, Data, DataError, DataFilter, DataProvider, DataScope, GroupInfo, Metadata,
+    TagInfo,
 };
 pub use discovery::{DiscoveryError, DiscoveryProvider, DiscoveryStream};
 pub use entity::{App, Area, Component, EntityCollection, EntityKind, EntityRef};

--- a/opensovd-models/src/data.rs
+++ b/opensovd-models/src/data.rs
@@ -75,13 +75,6 @@ pub struct DataErrorEntry {
     pub error: GenericError,
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct DataFilter {
-    pub groups: Option<Vec<String>>,
-    pub categories: Option<Vec<DataCategory>>,
-    pub tags: Option<Vec<String>>,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct DataError {
@@ -126,18 +119,6 @@ pub struct DataQuery {
     pub tags: Option<Vec<String>>,
     #[serde(default, rename = "include-schema")]
     pub include_schema: bool,
-}
-
-impl From<DataQuery> for DataFilter {
-    fn from(query: DataQuery) -> Self {
-        Self {
-            groups: query.groups,
-            categories: query
-                .categories
-                .map(|cats| cats.into_iter().map(DataCategory::from).collect()),
-            tags: query.tags,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -255,21 +236,5 @@ mod tests {
         assert_eq!(read_only.error_code, "read-only");
         assert_eq!(read_only.message, Some("Data resource is read-only".into()));
         assert_eq!(read_only.to_string(), "read-only");
-    }
-
-    #[test]
-    fn test_data_query_to_filter() {
-        let query = DataQuery {
-            groups: Some(vec!["sensors".into()]),
-            categories: Some(vec!["currentData".into()]),
-            tags: Some(vec!["temperature".into()]),
-            include_schema: true,
-        };
-
-        let filter: DataFilter = query.into();
-
-        assert_eq!(filter.groups, Some(vec!["sensors".into()]));
-        assert_eq!(filter.categories, Some(vec![DataCategory::CurrentData]));
-        assert_eq!(filter.tags, Some(vec!["temperature".into()]));
     }
 }

--- a/opensovd-providers/src/data/builder.rs
+++ b/opensovd-providers/src/data/builder.rs
@@ -8,7 +8,8 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use indexmap::IndexMap;
 use opensovd_core::{
-    CategoryInfo, Data, DataError, DataFilter, DataProvider, GroupInfo, Metadata, TagInfo,
+    CategoryInfo, Data, DataError, DataFilter, DataProvider, DataScope, GroupInfo, Metadata,
+    TagInfo,
 };
 use opensovd_models::data::DataCategory;
 use serde_json::Value;
@@ -264,34 +265,14 @@ impl BuiltDataProvider {
     }
 
     fn matches_filter(metadata: &Metadata, filter: &DataFilter) -> bool {
-        // Check categories filter
-        if !filter.categories.is_empty()
-            && !filter.categories.iter().any(|c| c == &metadata.category)
-        {
-            return false;
-        }
+        let scope_ok = match &filter.scope {
+            Some(DataScope::Groups(gs)) => gs.iter().any(|g| metadata.groups.contains(g)),
+            Some(DataScope::Categories(cs)) => cs.contains(&metadata.category),
+            None => true,
+        };
 
-        // Check groups filter
-        if !filter.groups.is_empty()
-            && !filter
-                .groups
-                .iter()
-                .any(|g| metadata.groups.iter().any(|mg| mg == g))
-        {
-            return false;
-        }
-
-        // Check tags filter
-        if !filter.tags.is_empty()
-            && !filter
-                .tags
-                .iter()
-                .any(|t| metadata.tags.iter().any(|mt| mt == t))
-        {
-            return false;
-        }
-
-        true
+        scope_ok
+            && (filter.tags.is_empty() || filter.tags.iter().any(|t| metadata.tags.contains(t)))
     }
 }
 
@@ -468,8 +449,8 @@ mod tests {
             .unwrap();
 
         let filter = DataFilter {
-            categories: vec!["identData".to_string()],
-            ..Default::default()
+            scope: Some(DataScope::Categories(vec!["identData".to_string()])),
+            tags: vec![],
         };
         let items = provider.list(filter).await.unwrap();
         assert_eq!(items.len(), 1);
@@ -496,8 +477,8 @@ mod tests {
             .unwrap();
 
         let filter = DataFilter {
+            scope: None,
             tags: vec!["monitoring".to_string()],
-            ..Default::default()
         };
         let items = provider.list(filter).await.unwrap();
         assert_eq!(items.len(), 1);
@@ -525,8 +506,8 @@ mod tests {
             .unwrap();
 
         let filter = DataFilter {
-            groups: vec!["info".to_string()],
-            ..Default::default()
+            scope: Some(DataScope::Groups(vec!["info".to_string()])),
+            tags: vec![],
         };
         let items = provider.list(filter).await.unwrap();
         assert_eq!(items.len(), 1);

--- a/opensovd-server/src/routes/data.rs
+++ b/opensovd-server/src/routes/data.rs
@@ -23,8 +23,7 @@ use axum::{
     routing::get,
 };
 use axum_extra::extract::{Query, WithRejection};
-use opensovd_core::DataFilter;
-use opensovd_core::Topology;
+use opensovd_core::{DataFilter, DataScope, Topology};
 use opensovd_models::Response;
 use opensovd_models::data::{
     DataCategories, DataCategoryInformation, DataGroups, DataGroupsQuery, DataList, DataQuery,
@@ -132,6 +131,28 @@ async fn component_data_groups(
     }))
 }
 
+/// Resolve a `DataQuery` into a provider `DataFilter`.
+///
+/// Applies groups/categories precedence: when both are given, groups wins and
+/// categories is ignored.
+fn data_filter(query: DataQuery) -> DataFilter {
+    let groups = query.groups.unwrap_or_default();
+    let categories = query.categories.unwrap_or_default();
+
+    let scope = if !groups.is_empty() {
+        Some(DataScope::Groups(groups))
+    } else if !categories.is_empty() {
+        Some(DataScope::Categories(categories))
+    } else {
+        None
+    };
+
+    DataFilter {
+        scope,
+        tags: query.tags.unwrap_or_default(),
+    }
+}
+
 /// GET /components/{component_id}/data - List data resources.
 ///
 /// Returns the list of data resources available for a component, optionally
@@ -149,11 +170,8 @@ async fn component_data_list(
         .data_provider()
         .ok_or_else(|| Error::ProviderNotAvailable("data".into()))?;
 
-    let filter = DataFilter {
-        groups: query.groups.clone().unwrap_or_default(),
-        categories: query.categories.clone().unwrap_or_default(),
-        tags: query.tags.clone().unwrap_or_default(),
-    };
+    let include_schema = query.include_schema;
+    let filter = data_filter(query);
 
     let items = provider
         .list(filter)
@@ -171,7 +189,7 @@ async fn component_data_list(
 
     Ok(Json(Response {
         data: DataList { items },
-        schema: query.include_schema.then(DataList::schema),
+        schema: include_schema.then(DataList::schema),
     }))
 }
 
@@ -308,11 +326,8 @@ async fn app_data_list(
         .data_provider()
         .ok_or_else(|| Error::ProviderNotAvailable("data".into()))?;
 
-    let filter = DataFilter {
-        groups: query.groups.clone().unwrap_or_default(),
-        categories: query.categories.clone().unwrap_or_default(),
-        tags: query.tags.clone().unwrap_or_default(),
-    };
+    let include_schema = query.include_schema;
+    let filter = data_filter(query);
 
     let items = provider
         .list(filter)
@@ -330,7 +345,7 @@ async fn app_data_list(
 
     Ok(Json(Response {
         data: DataList { items },
-        schema: query.include_schema.then(DataList::schema),
+        schema: include_schema.then(DataList::schema),
     }))
 }
 
@@ -378,4 +393,31 @@ async fn app_data_write(
 
     provider.write(&data_id, body.data).await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn query(groups: Vec<&str>, categories: Vec<&str>, tags: Vec<&str>) -> DataQuery {
+        DataQuery {
+            groups: Some(groups.into_iter().map(String::from).collect()),
+            categories: Some(categories.into_iter().map(String::from).collect()),
+            tags: Some(tags.into_iter().map(String::from).collect()),
+            include_schema: false,
+        }
+    }
+
+    #[test]
+    fn groups_take_precedence_over_categories() {
+        let filter = data_filter(query(vec!["g"], vec!["c"], vec![]));
+        assert_eq!(filter.scope, Some(DataScope::Groups(vec!["g".into()])));
+    }
+
+    #[test]
+    fn no_scope_leaves_tags_only() {
+        let filter = data_filter(query(vec![], vec![], vec!["t"]));
+        assert_eq!(filter.scope, None);
+        assert_eq!(filter.tags, vec!["t"]);
+    }
 }

--- a/opensovd-server/tests/data_filter.rs
+++ b/opensovd-server/tests/data_filter.rs
@@ -17,7 +17,9 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use http_body_util::BodyExt;
 use hyper::Request;
-use opensovd_core::{Component, Data, DataError, DataFilter, DataProvider, Metadata, Topology};
+use opensovd_core::{
+    Component, Data, DataError, DataFilter, DataProvider, DataScope, Metadata, Topology,
+};
 
 /// A data provider that records the last filter it was asked to list with.
 #[derive(Clone)]
@@ -77,9 +79,42 @@ async fn data_list_parses_repeated_filter_keys() {
     assert!(response.status().is_success(), "got {}", response.status());
 
     let filter = seen.lock().unwrap().clone().expect("provider was listed");
-    assert_eq!(filter.groups, vec!["sensors", "actuators"]);
-    assert_eq!(filter.categories, vec!["currentData", "x-custom"]);
+    // groups present, so the filter resolves to a Groups scope; categories dropped.
+    assert_eq!(
+        filter.scope,
+        Some(DataScope::Groups(vec![
+            "sensors".into(),
+            "actuators".into()
+        ]))
+    );
     assert_eq!(filter.tags, vec!["OBD", "ePTI"]);
+}
+
+#[tokio::test]
+async fn data_list_parses_categories_into_scope() {
+    let (server, seen) = server_with_recorder().await;
+    let client = common::client();
+
+    let request = Request::builder()
+        .uri(server.url(
+            "/sovd/v1/components/ECU/data\
+             ?categories=currentData&categories=x-custom&tags=OBD",
+        ))
+        .body(http_body_util::Empty::<bytes::Bytes>::new())
+        .unwrap();
+
+    let response = client.request(request).await.unwrap();
+    assert!(response.status().is_success(), "got {}", response.status());
+
+    let filter = seen.lock().unwrap().clone().expect("provider was listed");
+    assert_eq!(
+        filter.scope,
+        Some(DataScope::Categories(vec![
+            "currentData".into(),
+            "x-custom".into()
+        ]))
+    );
+    assert_eq!(filter.tags, vec!["OBD"]);
 }
 
 #[tokio::test]
@@ -96,9 +131,38 @@ async fn data_list_without_filter_is_empty() {
     assert!(response.status().is_success());
 
     let filter = seen.lock().unwrap().clone().expect("provider was listed");
-    assert!(filter.groups.is_empty());
-    assert!(filter.categories.is_empty());
+    assert!(filter.scope.is_none());
     assert!(filter.tags.is_empty());
+}
+
+#[tokio::test]
+async fn data_list_groups_take_precedence_over_categories() {
+    // "voltage" is currentData in group "power". groups=power selects it;
+    // categories=identData would exclude it, but groups wins.
+    let topology = opensovd_mocks::create_mock_topology().await;
+    let server = common::TestServer::builder()
+        .topology(topology)
+        .build()
+        .await;
+    let client = common::client();
+
+    let request = Request::builder()
+        .uri(server.url("/sovd/v1/components/ecu/data?groups=power&categories=identData"))
+        .body(http_body_util::Empty::<bytes::Bytes>::new())
+        .unwrap();
+
+    let response = client.request(request).await.unwrap();
+    assert!(response.status().is_success(), "got {}", response.status());
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let ids: Vec<&str> = json["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|item| item["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids, vec!["voltage"]);
 }
 
 #[tokio::test]

--- a/tests/opensovd-gateway/mocks/test_data_filter.py
+++ b/tests/opensovd-gateway/mocks/test_data_filter.py
@@ -20,7 +20,7 @@ IDENT = {"sw.version", "sw.build_date", "sw.sha1", "hw.version", "hw.revision", 
 CURRENT = {"voltage", "temperature"}
 
 
-# The mock provider applies filters as AND across dimensions, OR within each.
+# Scope (groups or categories, groups wins) AND-combines with tags; OR within each.
 @pytest.mark.parametrize(
     ("params", "expected"),
     [
@@ -33,6 +33,8 @@ CURRENT = {"voltage", "temperature"}
         ({"categories": "currentData", "tags": "sensor"}, CURRENT),
         ({"categories": "identData", "tags": "sensor"}, set()),
         ({"groups": "nonexistent"}, set()),
+        # groups wins, categories ignored.
+        ({"groups": "power", "categories": "identData"}, {"voltage"}),
     ],
 )
 def test_data_list_filter(client, params, expected):


### PR DESCRIPTION
## Summary

Querying an entity's data resources (`GET /{entity}/data`) filters the collection by `groups`, `categories`, and `tags`. The SOVD spec requires `groups` and `categories` to be mutually exclusive: `groups` takes precedence and `categories` is ignored when both are given, while `tags` is AND-combined. The server previously AND-combined `groups` and `categories`, over-filtering whenever both were present.

This encodes the rule in the type system so it cannot be violated: `DataFilter` now carries a `DataScope` sum type (`Groups` or `Categories`) plus `tags`, making the conflicting combination unrepresentable. The `data_filter` request-boundary helper resolves the precedence once. The dead `opensovd-models` `DataFilter` and its `From<DataQuery>` impl are removed.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have added or updated tests


