### PR TITLE
ci(deps): track uv updates in dependabot, drop pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,12 +14,12 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: monthly
     groups:
-      python:
+      uv:
         patterns:
           - "*"
     commit-message:


### PR DESCRIPTION
## Summary
Switch the Dependabot Python config from the `pip` ecosystem to `uv`. uv manages the Python packages and pip cannot keep `uv.lock` in sync, whereas the `uv` ecosystem updates both `pyproject.toml` and `uv.lock`.

## Checklist
- [x] I have tested my changes locally