### PR TITLE
fix(client): support data collection filtering by groups, categories, and tags

### DIFF
--- a/opensovd-client/src/data.rs
+++ b/opensovd-client/src/data.rs
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use std::borrow::Borrow;
+
 use opensovd_models::Response;
-use opensovd_models::data::{DataList, ReadResponse, WriteRequest};
+use opensovd_models::data::{DataCategory, DataList, ReadResponse, WriteRequest};
 use serde::Serialize;
 
-use crate::client::{Client, schema_query};
+use crate::client::{Client, encode, schema_query};
 use crate::error::Result;
 
 /// Request builder for listing data items on an entity.
@@ -13,6 +15,9 @@ pub struct ListDataRequest<'a> {
     pub(crate) client: &'a Client,
     pub(crate) path: String,
     pub(crate) schema: bool,
+    pub(crate) groups: Vec<String>,
+    pub(crate) categories: Vec<DataCategory>,
+    pub(crate) tags: Vec<String>,
 }
 
 impl ListDataRequest<'_> {
@@ -23,9 +28,59 @@ impl ListDataRequest<'_> {
         self
     }
 
+    /// Filter by data groups.
+    #[must_use]
+    pub fn groups<I, S>(mut self, groups: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.groups = groups.into_iter().map(|s| s.as_ref().to_owned()).collect();
+        self
+    }
+
+    /// Filter by data categories.
+    #[must_use]
+    pub fn categories<I, C>(mut self, categories: I) -> Self
+    where
+        I: IntoIterator<Item = C>,
+        C: Borrow<DataCategory>,
+    {
+        self.categories = categories.into_iter().map(|c| c.borrow().clone()).collect();
+        self
+    }
+
+    /// Filter by data tags.
+    #[must_use]
+    pub fn tags<I, S>(mut self, tags: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.tags = tags.into_iter().map(|s| s.as_ref().to_owned()).collect();
+        self
+    }
+
     /// Send the request.
     pub async fn send(&self) -> Result<Response<DataList>> {
-        self.client.get(&self.path, schema_query(self.schema)).await
+        let mut query: Vec<(String, String)> = Vec::new();
+        for g in &self.groups {
+            query.push(("groups".into(), encode(g)));
+        }
+        for c in &self.categories {
+            query.push(("categories".into(), encode(c.as_str())));
+        }
+        for t in &self.tags {
+            query.push(("tags".into(), encode(t)));
+        }
+        if let [(k, v)] = schema_query(self.schema) {
+            query.push((k.to_string(), v.to_string()));
+        }
+        let refs: Vec<(&str, &str)> = query
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        self.client.get(&self.path, &refs).await
     }
 }
 

--- a/opensovd-client/src/entities/app.rs
+++ b/opensovd-client/src/entities/app.rs
@@ -22,6 +22,9 @@ impl App<'_> {
             client: self.client,
             path: format!("/apps/{}/data", self.id),
             schema: false,
+            groups: Vec::new(),
+            categories: Vec::new(),
+            tags: Vec::new(),
         }
     }
 

--- a/opensovd-client/src/entities/component.rs
+++ b/opensovd-client/src/entities/component.rs
@@ -22,6 +22,9 @@ impl Component<'_> {
             client: self.client,
             path: format!("/components/{}/data", self.id),
             schema: false,
+            groups: Vec::new(),
+            categories: Vec::new(),
+            tags: Vec::new(),
         }
     }
 

--- a/opensovd-client/src/lib.rs
+++ b/opensovd-client/src/lib.rs
@@ -17,4 +17,5 @@ pub use client::{BuilderError, Client, ClientBuilder};
 pub use discovery::Discovery;
 pub use error::{Error, Result};
 pub use opensovd_models::Response;
+pub use opensovd_models::data::DataCategory;
 pub use opensovd_models::version::{SovdInfo, VendorInfo, VersionInfo};

--- a/opensovd-client/tests/data.rs
+++ b/opensovd-client/tests/data.rs
@@ -5,6 +5,7 @@ mod common;
 
 use common::mock_client;
 use mock_http_connector::Connector;
+use opensovd_client::DataCategory;
 use serde_json::json;
 
 #[tokio::test]
@@ -150,4 +151,110 @@ async fn list_data_with_schema() {
         .unwrap();
     assert!(result.data.items.is_empty());
     assert_eq!(result.schema.unwrap(), json!({"type": "object"}));
+}
+
+#[tokio::test]
+async fn list_data_with_groups() {
+    let mut builder = Connector::builder();
+    builder
+        .expect()
+        .with_uri("http://localhost/sovd/v1/components/ecu1/data?groups=a&groups=b")
+        .returning(json!({"items": []}).to_string())
+        .unwrap();
+    let client = mock_client(builder.build());
+    let result = client
+        .component("ecu1")
+        .list_data()
+        .groups(["a", "b"])
+        .send()
+        .await
+        .unwrap();
+    assert!(result.data.items.is_empty());
+}
+
+#[tokio::test]
+async fn list_data_with_categories() {
+    let mut builder = Connector::builder();
+    builder
+        .expect()
+        .with_uri(
+            "http://localhost/sovd/v1/components/ecu1/data?categories=identData&categories=currentData",
+        )
+        .returning(json!({"items": []}).to_string())
+        .unwrap();
+    let client = mock_client(builder.build());
+    let result = client
+        .component("ecu1")
+        .list_data()
+        .categories([DataCategory::IdentData, DataCategory::CurrentData])
+        .send()
+        .await
+        .unwrap();
+    assert!(result.data.items.is_empty());
+}
+
+#[tokio::test]
+async fn list_data_with_all_filters() {
+    let mut builder = Connector::builder();
+    builder
+        .expect()
+        .with_uri(
+            "http://localhost/sovd/v1/components/ecu1/data?groups=x&categories=storedData&tags=urgent&include-schema=true",
+        )
+        .returning(json!({"items": [], "schema": {"type": "object"}}).to_string())
+        .unwrap();
+    let client = mock_client(builder.build());
+    let result = client
+        .component("ecu1")
+        .list_data()
+        .groups(["x"])
+        .categories([DataCategory::StoredData])
+        .tags(["urgent"])
+        .schema(true)
+        .send()
+        .await
+        .unwrap();
+    assert!(result.data.items.is_empty());
+    assert_eq!(result.schema.unwrap(), json!({"type": "object"}));
+}
+
+#[tokio::test]
+async fn list_data_with_tags() {
+    let mut builder = Connector::builder();
+    builder
+        .expect()
+        .with_uri("http://localhost/sovd/v1/apps/diag/data?tags=safety&tags=critical")
+        .returning(json!({"items": []}).to_string())
+        .unwrap();
+    let client = mock_client(builder.build());
+    let result = client
+        .app("diag")
+        .list_data()
+        .tags(["safety", "critical"])
+        .send()
+        .await
+        .unwrap();
+    assert!(result.data.items.is_empty());
+}
+
+#[tokio::test]
+async fn list_data_percent_encodes_filter_values() {
+    let mut builder = Connector::builder();
+    builder
+        .expect()
+        .with_uri(
+            "http://localhost/sovd/v1/components/ecu1/data?groups=engine%20control&tags=a%26b",
+        )
+        .returning(json!({"items": []}).to_string())
+        .unwrap();
+    let client = mock_client(builder.build());
+    let result = client
+        .component("ecu1")
+        .list_data()
+        .groups(["engine control"])
+        .tags(["a&b"])
+        .send()
+        .await
+        .unwrap();
+    assert!(result.data.items.is_empty());
 }


### PR DESCRIPTION
## Summary

Extend the `opensovd-client` to support filtering data collections by groups, categories, and tags,
aligning the client with the server-side filtering added in PRs #89 and #93.

- Add `.groups()`, `.categories()`, and `.tags()` builder methods to `ListDataRequest`
- Re-export `DataCategory` from `opensovd-client` so consumers don't need a direct `opensovd-models` dependency
- Rewrite `ListDataRequest::send()` to emit repeated query parameter keys (e.g. `?groups=a&groups=b`)

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related

Closes #88

## Notes for Reviewers

- No changes to `client.rs` — the existing `get(&[(&str, &str)])` signature is preserved by building an owned `Vec<(String, String)>` inside `send()` and converting to temporary references.
- The 4 new tests use exact URI matching via `mock-http-connector`, covering groups, categories, tags, and a combined filter case.
- Server-side support was already merged in #89 and #93.