### PR TITLE
fix: first-interaction works on fork PRs

### DIFF
--- a/.github/workflows/first-interaction.yaml
+++ b/.github/workflows/first-interaction.yaml
@@ -6,7 +6,9 @@ name: first-interaction
 on:
   issues:
     types: [opened]
-  pull_request:
+  # pull_request_target gives a read-write token for fork PRs (plain
+  # pull_request is read-only there, so commenting fails with 403).
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
## Summary
The first-interaction workflow ran on `pull_request`, which gives fork PRs a read-only GITHUB_TOKEN, so posting the welcome comment failed with a 403. Switching to `pull_request_target` runs it with a read-write token so fork PRs work too. Safe here since the workflow only reads event metadata and never checks out PR code.

## Related
Fixes failing run: https://github.com/eclipse-opensovd/opensovd-core/actions/runs/27930905392/job/82654879658