### PR TITLE
chore(deps): bump rmcp from 1.7.0 to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
 dependencies = [
  "async-trait",
  "base64",
@@ -1493,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ tracing-subscriber = { version = "0.3", default-features = false }
 mock-http-connector = { version = "0.5", default-features = false }
 aws-lc-rs = { version = "1", default-features = false, features = ["aws-lc-sys"] }
 rand = { version = "0.10.1", default-features = false }
-rmcp = { version = "1.7.0" }
+rmcp = { version = "2.0.0" }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "tls12"] }
 rustls-pki-types = { version = "1", default-features = false, features = ["std"] }
 tokio-rustls = { version = "0.26", default-features = false }

--- a/opensovd-cli/mcp/src/main.rs
+++ b/opensovd-cli/mcp/src/main.rs
@@ -12,11 +12,9 @@ use rmcp::{
     RoleServer, ServerHandler, ServiceExt,
     handler::server::{router::prompt::PromptRouter, tool::ToolRouter},
     model::{
-        AnnotateAble, CallToolResult, ErrorData as McpError, GetPromptRequestParams,
-        GetPromptResult, Implementation, ListPromptsResult, ListResourcesResult,
-        PaginatedRequestParams, PromptMessage, PromptMessageRole, RawResource,
-        ReadResourceRequestParams, ReadResourceResult, ResourceContents, ServerCapabilities,
-        ServerInfo,
+        CallToolResult, ErrorData as McpError, GetPromptResult, Implementation,
+        ListResourcesResult, PaginatedRequestParams, PromptMessage, ReadResourceRequestParams,
+        ReadResourceResult, Resource, ResourceContents, Role, ServerCapabilities, ServerInfo,
     },
     prompt, prompt_handler, prompt_router,
     service::RequestContext,
@@ -97,7 +95,7 @@ impl McpServer {
     )]
     async fn explore_topology(&self) -> GetPromptResult {
         GetPromptResult::new(vec![PromptMessage::new_text(
-            PromptMessageRole::User,
+            Role::User,
             "Read the sovd://topology resource, then:\n\
                  1. List components\n\
                  2. List areas\n\
@@ -136,20 +134,11 @@ impl ServerHandler for McpServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, McpError> {
-        let resource = RawResource {
-            uri: TOPOLOGY_URI.into(),
-            name: "Vehicle Topology".into(),
-            description: Some(
-                "Snapshot of the SOVD entity hierarchy: components, areas, and apps.".into(),
-            ),
-            mime_type: Some("text/plain".into()),
-            title: None,
-            size: None,
-            icons: None,
-            meta: None,
-        };
+        let resource = Resource::new(TOPOLOGY_URI, "Vehicle Topology")
+            .with_description("Snapshot of the SOVD entity hierarchy: components, areas, and apps.")
+            .with_mime_type("text/plain");
         Ok(ListResourcesResult {
-            resources: vec![resource.no_annotation()],
+            resources: vec![resource],
             next_cursor: None,
             meta: None,
         })
@@ -366,9 +355,7 @@ mod tests {
 
         let text = match &result.contents[0] {
             ResourceContents::TextResourceContents { text, .. } => text.as_str(),
-            ResourceContents::BlobResourceContents { .. } => {
-                panic!("expected text resource contents")
-            }
+            _ => panic!("expected text resource contents"),
         };
 
         assert!(text.contains("Engine ECU"), "expected component name");
@@ -408,11 +395,11 @@ mod tests {
 
         assert!(!result.messages.is_empty(), "expected at least one message");
         let msg = &result.messages[0];
-        assert_eq!(msg.role, PromptMessageRole::User);
+        assert_eq!(msg.role, Role::User);
         match &msg.content {
-            rmcp::model::PromptMessageContent::Text { text } => {
+            rmcp::model::ContentBlock::Text(c) => {
                 assert!(
-                    text.contains("topology"),
+                    c.text.contains("topology"),
                     "expected prompt to mention topology"
                 );
             }


### PR DESCRIPTION
## Summary

Bumps `rmcp` from 1.7.0 to 2.0.0 and updates the MCP CLI server to the new API.

The 2.0 release reworks several model types. 

## Checklist

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests
