### PR TITLE
chore(deps): open separate PRs for major dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       actions:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: "chore(deps)"
 
@@ -22,6 +25,9 @@ updates:
       uv:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: "chore(deps)"
 
@@ -33,6 +39,9 @@ updates:
       cargo:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: "chore(deps)"
 
@@ -44,6 +53,9 @@ updates:
       docker:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: "chore(deps)"
 
@@ -55,5 +67,8 @@ updates:
       pre-commit:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

Dependabot currently bundles all updates per ecosystem into a single grouped PR. A major upgrade is likely to break the build, and since one failing update fails CI for the entire grouped PR, it blocks all the safe minor/patch bumps bundled with it until the breakage is fixed.

This restricts each Dependabot group to `minor` and `patch` update types. Major updates then fall outside the groups and get an individual PR each, so a breaking major bump can be fixed or deferred on its own while routine updates keep flowing in one grouped PR per ecosystem.

