### PR TITLE
feat(client): add request timeout to client builder

### DIFF
--- a/opensovd-client/Cargo.toml
+++ b/opensovd-client/Cargo.toml
@@ -25,7 +25,7 @@ serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
 tower = { workspace = true, features = ["util"] }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 
 [target.'cfg(unix)'.dependencies]
 tokio = { workspace = true, features = ["net"] }

--- a/opensovd-client/README.md
+++ b/opensovd-client/README.md
@@ -23,7 +23,7 @@ use opensovd_client::{Client, Error, SovdInfo, VendorInfo};
 // Point at the SOVD server root (no version identifier).
 let discovery = Client::builder()
     .base_uri("http://localhost:7690/sovd")?
-  .timeout(Duration::from_secs(5))
+    .timeout(Duration::from_secs(5))
     .discovery()?;
 
 // See what the server advertises.
@@ -38,16 +38,14 @@ for c in &client.list_components().send().await?.data.items {
 }
 
 match client.list_components().send().await {
-  Ok(list) => println!("{} components", list.data.items.len()),
-  Err(Error::Timeout(d)) => eprintln!("request timed out after {d:?}"),
-  Err(other) => return Err(other.into()),
+    Ok(list) => println!("{} components", list.data.items.len()),
+    Err(Error::Timeout(d)) => eprintln!("request timed out after {d:?}"),
+    Err(other) => return Err(other.into()),
 }
 # Ok(())
 # }
 ```
 
-`ClientBuilder::timeout` sets a total per-request deadline (connect, send, and
-response body collection). The timeout is inherited by clients returned from
 `Discovery::select`. If no timeout is configured, requests have no deadline.
 
 On Unix, `Discovery::connect_unix` / `connect_unix_abstract` reach `version-info`

--- a/opensovd-client/README.md
+++ b/opensovd-client/README.md
@@ -15,12 +15,15 @@
 ## Usage
 
 ```rust,no_run
-use opensovd_client::{Client, SovdInfo, VendorInfo};
+use std::time::Duration;
+
+use opensovd_client::{Client, Error, SovdInfo, VendorInfo};
 
 # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 // Point at the SOVD server root (no version identifier).
 let discovery = Client::builder()
     .base_uri("http://localhost:7690/sovd")?
+  .timeout(Duration::from_secs(5))
     .discovery()?;
 
 // See what the server advertises.
@@ -33,9 +36,19 @@ let client = discovery.select(|s: &SovdInfo<VendorInfo>| s.version == "1.1").awa
 for c in &client.list_components().send().await?.data.items {
     println!("component: {} ({})", c.id, c.name);
 }
+
+match client.list_components().send().await {
+  Ok(list) => println!("{} components", list.data.items.len()),
+  Err(Error::Timeout(d)) => eprintln!("request timed out after {d:?}"),
+  Err(other) => return Err(other.into()),
+}
 # Ok(())
 # }
 ```
+
+`ClientBuilder::timeout` sets a total per-request deadline (connect, send, and
+response body collection). The timeout is inherited by clients returned from
+`Discovery::select`. If no timeout is configured, requests have no deadline.
 
 On Unix, `Discovery::connect_unix` / `connect_unix_abstract` reach `version-info`
 over a Unix domain socket. A runnable example lives in `examples/client`.

--- a/opensovd-client/README.md
+++ b/opensovd-client/README.md
@@ -33,12 +33,13 @@ for info in discovery.versions::<VendorInfo>().await? {
 
 // Select a version and exercise it (or match on `vendor_info` via the `V` payload).
 let client = discovery.select(|s: &SovdInfo<VendorInfo>| s.version == "1.1").await?;
-for c in &client.list_components().send().await?.data.items {
-    println!("component: {} ({})", c.id, c.name);
-}
-
 match client.list_components().send().await {
-    Ok(list) => println!("{} components", list.data.items.len()),
+    Ok(list) => {
+        for c in &list.data.items {
+            println!("component: {} ({})", c.id, c.name);
+        }
+        println!("{} components", list.data.items.len());
+    }
     Err(Error::Timeout(d)) => eprintln!("request timed out after {d:?}"),
     Err(other) => return Err(other.into()),
 }
@@ -46,7 +47,7 @@ match client.list_components().send().await {
 # }
 ```
 
-`Discovery::select`. If no timeout is configured, requests have no deadline.
+If no timeout is configured, requests have no deadline.
 
 On Unix, `Discovery::connect_unix` / `connect_unix_abstract` reach `version-info`
 over a Unix domain socket. A runnable example lives in `examples/client`.

--- a/opensovd-client/src/client.rs
+++ b/opensovd-client/src/client.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use bytes::Bytes;
 use http_body::Body;
@@ -49,6 +49,7 @@ pub enum BuilderError {
 #[must_use]
 pub struct ClientBuilder<Conn = HttpConnector, Layers = Identity> {
     base_uri: Option<http::Uri>,
+    timeout: Option<Duration>,
     connector: Conn,
     layer: Layers,
 }
@@ -57,6 +58,7 @@ impl ClientBuilder<HttpConnector, Identity> {
     fn new() -> Self {
         Self {
             base_uri: None,
+            timeout: None,
             connector: HttpConnector::new(),
             layer: Identity::new(),
         }
@@ -85,9 +87,16 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
     pub fn connector<NewConn>(self, connector: NewConn) -> ClientBuilder<NewConn, Layers> {
         ClientBuilder {
             base_uri: self.base_uri,
+            timeout: self.timeout,
             connector,
             layer: self.layer,
         }
+    }
+
+    /// Set a total per-request timeout covering send and full response body collection.
+    pub fn timeout(mut self, duration: Duration) -> Self {
+        self.timeout = Some(duration);
+        self
     }
 
     /// Add a Tower layer to the HTTP client stack.
@@ -96,6 +105,7 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
     pub fn layer<NewLayer>(self, layer: NewLayer) -> ClientBuilder<Conn, Stack<NewLayer, Layers>> {
         ClientBuilder {
             base_uri: self.base_uri,
+            timeout: self.timeout,
             connector: self.connector,
             layer: Stack::new(layer, self.layer),
         }
@@ -132,6 +142,7 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
         );
         Ok(Client {
             base_uri,
+            timeout: self.timeout,
             http: BoxCloneSyncService::new(service),
         })
     }
@@ -171,6 +182,7 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
 #[derive(Clone)]
 pub struct Client {
     pub(crate) base_uri: http::Uri,
+    pub(crate) timeout: Option<Duration>,
     pub(crate) http: HttpService,
 }
 
@@ -282,24 +294,34 @@ impl Client {
     ///
     /// Returns an [`Error::ApiError`] if the server responds with a non-success status.
     pub(crate) async fn request(&self, req: http::Request<Full<Bytes>>) -> Result<Bytes> {
-        let resp = self
-            .http
-            .clone()
-            .call(req)
-            .await
-            .map_err(|e| Error::Service { source: e })?;
-        let status = resp.status();
-        let body = resp
-            .into_body()
-            .collect()
-            .await
-            .map_err(|e| Error::Service { source: e })?
-            .to_bytes();
-        if !status.is_success() {
-            let error = serde_json::from_slice(&body).ok();
-            return Err(Error::ApiError { status, error });
+        let request = async {
+            let resp = self
+                .http
+                .clone()
+                .call(req)
+                .await
+                .map_err(|e| Error::Service { source: e })?;
+            let status = resp.status();
+            let body = resp
+                .into_body()
+                .collect()
+                .await
+                .map_err(|e| Error::Service { source: e })?
+                .to_bytes();
+            if !status.is_success() {
+                let error = serde_json::from_slice(&body).ok();
+                return Err(Error::ApiError { status, error });
+            }
+            Ok(body)
+        };
+
+        if let Some(timeout) = self.timeout {
+            tokio::time::timeout(timeout, request)
+                .await
+                .map_err(|_| Error::Timeout(timeout))?
+        } else {
+            request.await
         }
-        Ok(body)
     }
 }
 

--- a/opensovd-client/src/discovery.rs
+++ b/opensovd-client/src/discovery.rs
@@ -80,6 +80,7 @@ impl Discovery {
             .0;
         Ok(Client {
             base_uri: advertised.parse()?,
+            timeout: self.inner.timeout,
             http: self.inner.http.clone(),
         })
     }

--- a/opensovd-client/src/error.rs
+++ b/opensovd-client/src/error.rs
@@ -36,6 +36,10 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
+    /// Request timed out before receiving a full response.
+    #[error("request timed out after {0:?}")]
+    Timeout(std::time::Duration),
+
     /// JSON serialization/deserialization error.
     #[error("json error: {0}")]
     Json(#[from] serde_json::Error),

--- a/opensovd-client/tests/client.rs
+++ b/opensovd-client/tests/client.rs
@@ -4,6 +4,8 @@
 
 mod common;
 
+use std::time::Duration;
+
 use common::mock_client;
 use mock_http_connector::Connector;
 use serde_json::json;
@@ -74,8 +76,6 @@ async fn with_layer_builds_client() {
 
 #[tokio::test]
 async fn timeout_layer_times_out() {
-    use std::time::Duration;
-
     use tokio::io::AsyncWriteExt;
     use tokio::net::TcpListener;
     use tower::timeout::TimeoutLayer;
@@ -113,4 +113,40 @@ async fn timeout_layer_times_out() {
         source.is::<tower::timeout::error::Elapsed>(),
         "expected timeout error, got: {source:?}"
     );
+}
+
+#[tokio::test]
+async fn builder_timeout_returns_typed_timeout_error() {
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+
+    // Spawn a slow server that delays 2s before responding
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        // Wait longer than the client timeout
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        // Send a valid HTTP response (client won't see this due to timeout)
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\n{\"items\": []}";
+        let _ = socket.write_all(response.as_bytes()).await;
+    });
+
+    // Build client with first-class 1s request timeout
+    let client = opensovd_client::Client::builder()
+        .base_uri(format!("http://{addr}/sovd/v1"))
+        .expect("valid URI")
+        .timeout(Duration::from_secs(1))
+        .build()
+        .expect("valid test client with request timeout");
+
+    let err = client.list_components().send().await.unwrap_err();
+
+    match err {
+        opensovd_client::Error::Timeout(duration) => {
+            assert_eq!(duration, Duration::from_secs(1));
+        }
+        other => panic!("expected Timeout error, got: {other:?}"),
+    }
 }

--- a/opensovd-client/tests/discovery.rs
+++ b/opensovd-client/tests/discovery.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
+use std::time::Duration;
+
 use mock_http_connector::Connector;
 use opensovd_client::{Client, SovdInfo, VendorInfo};
 use serde_json::json;
@@ -41,6 +43,60 @@ async fn select_reuses_transport() {
     // The selected client must reuse the same (mock) transport and hit the advertised base.
     let list = client.list_components().send().await.unwrap();
     assert!(list.data.items.is_empty());
+}
+
+#[tokio::test]
+async fn select_inherits_request_timeout() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    // Advertise a versioned base URI, then delay the selected client's /components response.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        // First connection: discovery /version-info request.
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf = [0u8; 1024];
+        let _ = socket.read(&mut buf).await;
+        let version_info = format!(
+            "{{\"sovd_info\":[{{\"version\":\"1.1\",\"base_uri\":\"http://{addr}/sovd/v1\"}}]}}"
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            version_info.len(),
+            version_info
+        );
+        let _ = socket.write_all(response.as_bytes()).await;
+
+        // Second connection: selected client /components request, intentionally slow.
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let _ = socket.read(&mut buf).await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let body = "{\"items\": []}";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = socket.write_all(response.as_bytes()).await;
+    });
+
+    let client = Client::builder()
+        .base_uri(format!("http://{addr}/sovd"))
+        .expect("valid URI")
+        .timeout(Duration::from_secs(1))
+        .discovery()
+        .expect("valid discovery client")
+        .select(|s: &SovdInfo<serde_json::Value>| s.version == "1.1")
+        .await
+        .unwrap();
+
+    let err = client.list_components().send().await.unwrap_err();
+    assert!(
+        matches!(err, opensovd_client::Error::Timeout(d) if d == Duration::from_secs(1)),
+        "expected propagated Timeout(1s), got: {err:?}"
+    );
 }
 
 #[tokio::test]

--- a/opensovd-client/tests/discovery.rs
+++ b/opensovd-client/tests/discovery.rs
@@ -47,45 +47,30 @@ async fn select_reuses_transport() {
 
 #[tokio::test]
 async fn select_inherits_request_timeout() {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::TcpListener;
-
-    // Advertise a versioned base URI, then delay the selected client's /components response.
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-
-    tokio::spawn(async move {
-        // First connection: discovery /version-info request.
-        let (mut socket, _) = listener.accept().await.unwrap();
-        let mut buf = [0u8; 1024];
-        let _ = socket.read(&mut buf).await;
-        let version_info = format!(
-            "{{\"sovd_info\":[{{\"version\":\"1.1\",\"base_uri\":\"http://{addr}/sovd/v1\"}}]}}"
-        );
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-            version_info.len(),
-            version_info
-        );
-        let _ = socket.write_all(response.as_bytes()).await;
-
-        // Second connection: selected client /components request, intentionally slow.
-        let (mut socket, _) = listener.accept().await.unwrap();
-        let _ = socket.read(&mut buf).await;
-        tokio::time::sleep(Duration::from_secs(2)).await;
-        let body = "{\"items\": []}";
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        let _ = socket.write_all(response.as_bytes()).await;
-    });
+    let mut b = Connector::builder();
+    b.expect()
+        .with_uri("http://localhost:7690/sovd/version-info")
+        .returning(
+            json!({"sovd_info": [{
+                "version": "1.1",
+                "base_uri": "http://localhost:7690/sovd/v1"
+            }]})
+            .to_string(),
+        )
+        .unwrap();
+    b.expect()
+        .with_uri("http://localhost:7690/sovd/v1/components")
+        .returning(|_| async {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            json!({"items": []}).to_string()
+        })
+        .unwrap();
 
     let client = Client::builder()
-        .base_uri(format!("http://{addr}/sovd"))
+        .base_uri("http://localhost:7690/sovd")
         .expect("valid URI")
         .timeout(Duration::from_secs(1))
+        .connector(b.build())
         .discovery()
         .expect("valid discovery client")
         .select(|s: &SovdInfo<serde_json::Value>| s.version == "1.1")


### PR DESCRIPTION
## Summary
- add ClientBuilder timeout(Duration) with no-timeout default
- enforce request deadline in Client request using tokio time timeout

## Checklist
- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
Issue: eclipse-opensovd/opensovd-core#122