### PR TITLE
fix(client): drive poll_ready before calling the http service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,8 +1977,10 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/opensovd-client/Cargo.toml
+++ b/opensovd-client/Cargo.toml
@@ -33,7 +33,7 @@ tower-service = { workspace = true }
 
 [dev-dependencies]
 mock-http-connector = { workspace = true, features = ["hyper_1"] }
-tower = { workspace = true, features = ["timeout"] }
+tower = { workspace = true, features = ["timeout", "limit"] }
 tokio = { workspace = true, features = ["rt", "macros", "time", "net", "io-util"] }
 serde_json = { workspace = true, features = ["std"] }
 

--- a/opensovd-client/src/client.rs
+++ b/opensovd-client/src/client.rs
@@ -14,7 +14,7 @@ use serde::{Serialize, de::DeserializeOwned};
 use thiserror::Error;
 use tokio::sync::OnceCell;
 use tower::{
-    Layer, Service,
+    Layer, Service, ServiceExt,
     layer::util::{Identity, Stack},
     util::{BoxCloneSyncService, MapErrLayer, MapResponseLayer},
 };
@@ -298,7 +298,7 @@ impl Client {
             let resp = self
                 .http
                 .clone()
-                .call(req)
+                .oneshot(req)
                 .await
                 .map_err(|e| Error::Service { source: e })?;
             let status = resp.status();

--- a/opensovd-client/tests/client.rs
+++ b/opensovd-client/tests/client.rs
@@ -150,3 +150,30 @@ async fn builder_timeout_returns_typed_timeout_error() {
         other => panic!("expected Timeout error, got: {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn backpressure_layer_does_not_panic() {
+    use tower::limit::ConcurrencyLimitLayer;
+
+    let mut builder = Connector::builder();
+    builder
+        .expect()
+        .with_uri("http://localhost/sovd/v1/components")
+        .times(2)
+        .returning(json!({"items": []}).to_string())
+        .unwrap();
+
+    // A limit layer requires poll_ready to be driven before call.
+    let client = opensovd_client::Client::builder()
+        .base_uri("http://localhost/sovd/v1")
+        .expect("valid URI")
+        .layer(ConcurrencyLimitLayer::new(1))
+        .connector(builder.build())
+        .build()
+        .expect("valid test client with limit layer");
+
+    for _ in 0..2 {
+        let list = client.list_components().send().await.unwrap();
+        assert!(list.data.items.is_empty());
+    }
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

`Client::request` invoked the tower service via `call()` without driving
`poll_ready`, violating the tower service contract. Backpressure layers added
through `ClientBuilder::layer`, such as `ConcurrencyLimitLayer`, panicked on
the first request with "max requests in-flight; poll_ready must be called
first". The fix uses `ServiceExt::oneshot`, which waits for readiness before
dispatching.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated tests

## Related

Found while reviewing #125.

## Notes for Reviewers

The regression test sends two sequential requests through a
`ConcurrencyLimitLayer::new(1)`. It panics on main and passes with the fix.
The tower `limit` feature is enabled for dev-dependencies only.
