### PR TITLE
feat(client): Support builder configuration over unix socket transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +924,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1109,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tower",
@@ -1512,6 +1525,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +1840,18 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/opensovd-client/Cargo.toml
+++ b/opensovd-client/Cargo.toml
@@ -36,6 +36,7 @@ mock-http-connector = { workspace = true, features = ["hyper_1"] }
 tower = { workspace = true, features = ["timeout"] }
 tokio = { workspace = true, features = ["rt", "macros", "time", "net", "io-util"] }
 serde_json = { workspace = true, features = ["std"] }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/opensovd-client/README.md
+++ b/opensovd-client/README.md
@@ -52,4 +52,24 @@ If no timeout is configured, requests have no deadline.
 On Unix, `Discovery::connect_unix` / `connect_unix_abstract` reach `version-info`
 over a Unix domain socket. A runnable example lives in `examples/client`.
 
+To combine Unix sockets with builder configuration such as request timeouts,
+switch the builder transport explicitly:
+
+```rust,no_run
+use std::time::Duration;
+
+use opensovd_client::Client;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let client = Client::builder()
+    .base_uri("http://localhost/sovd/v1")?
+    .timeout(Duration::from_secs(5))
+    .unix_socket("/run/sovd.sock")
+    .build()?;
+
+let _components = client.list_components().send().await?;
+# Ok(())
+# }
+```
+
 Part of [OpenSOVD Core](https://github.com/eclipse-opensovd/opensovd-core).

--- a/opensovd-client/README.md
+++ b/opensovd-client/README.md
@@ -56,11 +56,14 @@ To combine Unix sockets with builder configuration such as request timeouts,
 switch the builder transport explicitly:
 
 ```rust,no_run
-use std::time::Duration;
-
 use opensovd_client::Client;
 
+# #[cfg(unix)]
+use std::time::Duration;
+
 # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+# #[cfg(unix)]
+# {
 let client = Client::builder()
     .base_uri("http://localhost/sovd/v1")?
     .timeout(Duration::from_secs(5))
@@ -68,6 +71,7 @@ let client = Client::builder()
     .build()?;
 
 let _components = client.list_components().send().await?;
+# }
 # Ok(())
 # }
 ```

--- a/opensovd-client/src/client.rs
+++ b/opensovd-client/src/client.rs
@@ -23,6 +23,8 @@ use crate::discovery::Discovery;
 use crate::entities::{App, Area, Component};
 use crate::error::{Error, Result};
 use crate::list::ListEntitiesRequest;
+#[cfg(unix)]
+use crate::unix::UnixConnector;
 
 /// Boxed error type for HTTP service flexibility with layers.
 pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync>;
@@ -175,6 +177,26 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
             inner: self.build()?,
             cache: Arc::new(OnceCell::new()),
         })
+    }
+}
+
+#[cfg(unix)]
+impl<Conn, Layers> ClientBuilder<Conn, Layers> {
+    /// Route requests over a Unix domain socket at the given filesystem path.
+    pub fn unix_socket(
+        self,
+        path: impl AsRef<std::path::Path>,
+    ) -> ClientBuilder<UnixConnector, Layers> {
+        self.connector(UnixConnector::new(path))
+    }
+
+    /// Route requests over a Linux abstract Unix domain socket.
+    #[cfg(target_os = "linux")]
+    pub fn unix_socket_abstract(
+        self,
+        name: impl AsRef<[u8]>,
+    ) -> ClientBuilder<UnixConnector, Layers> {
+        self.connector(UnixConnector::abstract_name(name))
     }
 }
 

--- a/opensovd-client/src/client.rs
+++ b/opensovd-client/src/client.rs
@@ -182,7 +182,11 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
 
 #[cfg(unix)]
 impl<Conn, Layers> ClientBuilder<Conn, Layers> {
-    /// Route requests over a Unix domain socket at the given filesystem path.
+    /// Route requests over a Unix domain socket (filesystem path).
+    ///
+    /// The eventual base URI should include the path prefix,
+    /// e.g. `http://localhost/sovd/v1`. The host is ignored;
+    /// all requests are routed to the socket at `path`.
     pub fn unix_socket(
         self,
         path: impl AsRef<std::path::Path>,
@@ -190,7 +194,11 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
         self.connector(UnixConnector::new(path))
     }
 
-    /// Route requests over a Linux abstract Unix domain socket.
+    /// Route requests over a Linux abstract Unix socket.
+    ///
+    /// `name` is the abstract socket name (without a leading null byte).
+    /// The eventual base URI should include the path prefix,
+    /// e.g. `http://localhost/sovd/v1`.
     #[cfg(target_os = "linux")]
     pub fn unix_socket_abstract(
         self,
@@ -362,8 +370,7 @@ impl Client {
         uri: &str,
         path: impl AsRef<std::path::Path>,
     ) -> std::result::Result<Self, BuilderError> {
-        let connector = crate::unix::UnixConnector::new(path);
-        Self::builder().base_uri(uri)?.connector(connector).build()
+        Self::builder().base_uri(uri)?.unix_socket(path).build()
     }
 
     /// Connect to an SOVD server over a Linux abstract Unix socket.
@@ -380,8 +387,10 @@ impl Client {
         uri: &str,
         name: impl AsRef<[u8]>,
     ) -> std::result::Result<Self, BuilderError> {
-        let connector = crate::unix::UnixConnector::abstract_name(name);
-        Self::builder().base_uri(uri)?.connector(connector).build()
+        Self::builder()
+            .base_uri(uri)?
+            .unix_socket_abstract(name)
+            .build()
     }
 }
 

--- a/opensovd-client/src/lib.rs
+++ b/opensovd-client/src/lib.rs
@@ -19,3 +19,5 @@ pub use error::{Error, Result};
 pub use opensovd_models::Response;
 pub use opensovd_models::data::DataCategory;
 pub use opensovd_models::version::{SovdInfo, VendorInfo, VersionInfo};
+#[cfg(unix)]
+pub use unix::UnixConnector;

--- a/opensovd-client/src/unix.rs
+++ b/opensovd-client/src/unix.rs
@@ -26,13 +26,13 @@ enum SocketAddr {
 /// Implements [`tower_service::Service<Uri>`] so it can be used with
 /// `hyper_util::client::legacy::Client`.
 #[derive(Debug, Clone)]
-pub(crate) struct UnixConnector {
+pub struct UnixConnector {
     addr: SocketAddr,
 }
 
 impl UnixConnector {
     /// Create a connector for a filesystem Unix socket path.
-    pub(crate) fn new(path: impl AsRef<Path>) -> Self {
+    pub fn new(path: impl AsRef<Path>) -> Self {
         Self {
             addr: SocketAddr::Path(path.as_ref().to_owned()),
         }
@@ -43,7 +43,7 @@ impl UnixConnector {
     /// The `name` should be the abstract socket name **without** a leading null
     /// byte - the connector prepends it automatically.
     #[cfg(target_os = "linux")]
-    pub(crate) fn abstract_name(name: impl AsRef<[u8]>) -> Self {
+    pub fn abstract_name(name: impl AsRef<[u8]>) -> Self {
         let mut addr = vec![0u8];
         addr.extend_from_slice(name.as_ref());
         Self {

--- a/opensovd-client/tests/unix.rs
+++ b/opensovd-client/tests/unix.rs
@@ -4,6 +4,8 @@
 #![cfg(unix)]
 #![allow(clippy::unwrap_used)]
 
+use std::time::Duration;
+
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixListener;
 
@@ -87,4 +89,97 @@ async fn connect_unix_not_found() {
         matches!(err, opensovd_client::Error::Service { .. }),
         "expected Error::Service, got: {err:?}"
     );
+}
+
+#[tokio::test]
+async fn builder_unix_socket_timeout_returns_typed_timeout_error() {
+    let dir = std::env::temp_dir().join(format!(
+        "opensovd-client-timeout-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let sock_path = dir.join("timeout.sock");
+
+    let _ = std::fs::remove_file(&sock_path);
+
+    let listener = UnixListener::bind(&sock_path).unwrap();
+
+    tokio::spawn(async move {
+        let (_stream, _) = listener.accept().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    });
+
+    let client = opensovd_client::Client::builder()
+        .base_uri("http://localhost/sovd/v1")
+        .unwrap()
+        .timeout(Duration::from_secs(1))
+        .unix_socket(&sock_path)
+        .build()
+        .unwrap();
+
+    let err = client.list_components().send().await.unwrap_err();
+
+    match err {
+        opensovd_client::Error::Timeout(duration) => {
+            assert_eq!(duration, Duration::from_secs(1));
+        }
+        other => panic!("expected Timeout error, got: {other:?}"),
+    }
+
+    let _ = std::fs::remove_file(&sock_path);
+    let _ = std::fs::remove_dir(&dir);
+}
+
+#[tokio::test]
+async fn builder_can_use_exported_unix_connector() {
+    let dir = std::env::temp_dir().join(format!(
+        "opensovd-client-builder-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let sock_path = dir.join("builder.sock");
+
+    let _ = std::fs::remove_file(&sock_path);
+
+    let listener = UnixListener::bind(&sock_path).unwrap();
+
+    let body = r#"{"items":[]}"#;
+    tokio::spawn(async move {
+        serve_one(&listener, body).await;
+    });
+
+    let client = opensovd_client::Client::builder()
+        .base_uri("http://localhost/sovd/v1")
+        .unwrap()
+        .connector(opensovd_client::UnixConnector::new(&sock_path))
+        .build()
+        .unwrap();
+    let result = client.list_components().send().await.unwrap();
+    assert!(result.data.items.is_empty());
+
+    let _ = std::fs::remove_file(&sock_path);
+    let _ = std::fs::remove_dir(&dir);
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn builder_unix_socket_abstract() {
+    let name = format!("opensovd-builder-test-{}", std::process::id());
+
+    let abstract_path = format!("\0{name}");
+    let listener = UnixListener::bind(&abstract_path).unwrap();
+
+    let body = r#"{"items":[]}"#;
+    tokio::spawn(async move {
+        serve_one(&listener, body).await;
+    });
+
+    let client = opensovd_client::Client::builder()
+        .base_uri("http://localhost/sovd/v1")
+        .unwrap()
+        .unix_socket_abstract(&name)
+        .build()
+        .unwrap();
+    let result = client.list_components().send().await.unwrap();
+    assert!(result.data.items.is_empty());
 }

--- a/opensovd-client/tests/unix.rs
+++ b/opensovd-client/tests/unix.rs
@@ -6,6 +6,7 @@
 
 use std::time::Duration;
 
+use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixListener;
 
@@ -93,20 +94,15 @@ async fn connect_unix_not_found() {
 
 #[tokio::test]
 async fn builder_unix_socket_timeout_returns_typed_timeout_error() {
-    let dir = std::env::temp_dir().join(format!(
-        "opensovd-client-timeout-test-{}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
-    let sock_path = dir.join("timeout.sock");
-
-    let _ = std::fs::remove_file(&sock_path);
+    let dir = TempDir::new().unwrap();
+    let sock_path = dir.path().join("timeout.sock");
 
     let listener = UnixListener::bind(&sock_path).unwrap();
 
     tokio::spawn(async move {
         let (_stream, _) = listener.accept().await.unwrap();
         tokio::time::sleep(Duration::from_secs(2)).await;
+        std::future::pending::<()>().await;
     });
 
     let client = opensovd_client::Client::builder()
@@ -125,21 +121,12 @@ async fn builder_unix_socket_timeout_returns_typed_timeout_error() {
         }
         other => panic!("expected Timeout error, got: {other:?}"),
     }
-
-    let _ = std::fs::remove_file(&sock_path);
-    let _ = std::fs::remove_dir(&dir);
 }
 
 #[tokio::test]
 async fn builder_can_use_exported_unix_connector() {
-    let dir = std::env::temp_dir().join(format!(
-        "opensovd-client-builder-test-{}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
-    let sock_path = dir.join("builder.sock");
-
-    let _ = std::fs::remove_file(&sock_path);
+    let dir = TempDir::new().unwrap();
+    let sock_path = dir.path().join("builder.sock");
 
     let listener = UnixListener::bind(&sock_path).unwrap();
 
@@ -156,9 +143,6 @@ async fn builder_can_use_exported_unix_connector() {
         .unwrap();
     let result = client.list_components().send().await.unwrap();
     assert!(result.data.items.is_empty());
-
-    let _ = std::fs::remove_file(&sock_path);
-    let _ = std::fs::remove_dir(&dir);
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary
- Exposed UnixConnector as a public type and re-exported it from the crate root.
- Added ClientBuilder::unix_socket(path) and ClientBuilder::unix_socket_abstract(name) convenience methods.

## Checklist
- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
Issue: eclipse-opensovd/opensovd-core#126