### PR TITLE
feat(client): Add authentication

### DIFF
--- a/opensovd-client/README.md
+++ b/opensovd-client/README.md
@@ -17,12 +17,13 @@
 ```rust,no_run
 use std::time::Duration;
 
-use opensovd_client::{Client, Error, SovdInfo, VendorInfo};
+use opensovd_client::{Auth, Client, Error, SovdInfo, VendorInfo};
 
 # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 // Point at the SOVD server root (no version identifier).
 let discovery = Client::builder()
     .base_uri("http://localhost:7690/sovd")?
+    .auth(Auth::bearer("example-token"))
     .timeout(Duration::from_secs(5))
     .discovery()?;
 
@@ -48,6 +49,10 @@ match client.list_components().send().await {
 ```
 
 If no timeout is configured, requests have no deadline.
+
+Authentication is optional. When configured on the builder, the client sends the
+credential as an `Authorization` header on every request, and clients returned
+from `Discovery::select` inherit the same credential.
 
 On Unix, `Discovery::connect_unix` / `connect_unix_abstract` reach `version-info`
 over a Unix domain socket. A runnable example lives in `examples/client`.

--- a/opensovd-client/src/auth.rs
+++ b/opensovd-client/src/auth.rs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+
+/// Authentication configuration for the SOVD client.
+#[derive(Clone)]
+#[non_exhaustive]
+pub enum Auth {
+    /// Send a bearer token in the `Authorization` header on every request.
+    Bearer(String),
+}
+
+impl Auth {
+    /// Create bearer token authentication.
+    #[must_use]
+    pub fn bearer(token: impl Into<String>) -> Self {
+        Self::Bearer(token.into())
+    }
+}
+
+impl fmt::Debug for Auth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Bearer(_) => f.write_str("Bearer(****)"),
+        }
+    }
+}
+
+impl From<String> for Auth {
+    fn from(value: String) -> Self {
+        Self::Bearer(value)
+    }
+}
+
+impl From<&str> for Auth {
+    fn from(value: &str) -> Self {
+        Self::Bearer(value.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Auth;
+
+    #[test]
+    fn debug_redacts_bearer_token() {
+        let auth = Auth::bearer("secret-token");
+
+        let debug = format!("{auth:?}");
+
+        assert!(!debug.contains("secret-token"));
+        assert_eq!(debug, "Bearer(****)");
+    }
+}

--- a/opensovd-client/src/client.rs
+++ b/opensovd-client/src/client.rs
@@ -19,6 +19,7 @@ use tower::{
     util::{BoxCloneSyncService, MapErrLayer, MapResponseLayer},
 };
 
+use crate::auth::Auth;
 use crate::discovery::Discovery;
 use crate::entities::{App, Area, Component};
 use crate::error::{Error, Result};
@@ -43,6 +44,9 @@ pub enum BuilderError {
     /// Invalid base URI.
     #[error("invalid base URI")]
     InvalidUri,
+    /// Invalid authentication token.
+    #[error("invalid authentication token")]
+    InvalidToken,
 }
 
 /// Builder for constructing a [`Client`] with custom configuration.
@@ -50,6 +54,7 @@ pub enum BuilderError {
 pub struct ClientBuilder<Conn = HttpConnector, Layers = Identity> {
     base_uri: Option<http::Uri>,
     timeout: Option<Duration>,
+    auth: Option<Auth>,
     connector: Conn,
     layer: Layers,
 }
@@ -59,6 +64,7 @@ impl ClientBuilder<HttpConnector, Identity> {
         Self {
             base_uri: None,
             timeout: None,
+            auth: None,
             connector: HttpConnector::new(),
             layer: Identity::new(),
         }
@@ -88,6 +94,7 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
         ClientBuilder {
             base_uri: self.base_uri,
             timeout: self.timeout,
+            auth: self.auth,
             connector,
             layer: self.layer,
         }
@@ -99,6 +106,14 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
         self
     }
 
+    /// Set authentication to apply to every request.
+    ///
+    /// The credential is validated when calling [`Self::build`] or [`Self::discovery`].
+    pub fn auth(mut self, auth: impl Into<Auth>) -> Self {
+        self.auth = Some(auth.into());
+        self
+    }
+
     /// Add a Tower layer to the HTTP client stack.
     ///
     /// Layers are applied in order: the first layer added is the outermost.
@@ -106,6 +121,7 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
         ClientBuilder {
             base_uri: self.base_uri,
             timeout: self.timeout,
+            auth: self.auth,
             connector: self.connector,
             layer: Stack::new(layer, self.layer),
         }
@@ -116,6 +132,8 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
     /// # Errors
     ///
     /// Returns [`BuilderError::NoBaseUri`] if the base URI has not been set.
+    /// Returns [`BuilderError::InvalidToken`] if the configured authentication token cannot be
+    /// encoded as an HTTP header value.
     pub fn build<ResBody>(self) -> std::result::Result<Client, BuilderError>
     where
         Conn: hyper_util::client::legacy::connect::Connect + Clone + Send + Sync + 'static,
@@ -131,6 +149,17 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
         ResBody::Error: Into<BoxError>,
     {
         let base_uri = self.base_uri.ok_or(BuilderError::NoBaseUri)?;
+        let auth = self
+            .auth
+            .map(|auth| match auth {
+                Auth::Bearer(token) => http::HeaderValue::from_str(&format!("Bearer {token}")),
+            })
+            .transpose()
+            .map_err(|_| BuilderError::InvalidToken)?
+            .map(|mut header| {
+                header.set_sensitive(true);
+                header
+            });
         let http = legacy::Client::builder(TokioExecutor::new()).build(self.connector);
         let service = self.layer.layer(http);
         // Map response body to BoxBody and service error to BoxError
@@ -143,6 +172,7 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
         Ok(Client {
             base_uri,
             timeout: self.timeout,
+            auth,
             http: BoxCloneSyncService::new(service),
         })
     }
@@ -157,6 +187,8 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
     /// # Errors
     ///
     /// Returns [`BuilderError::NoBaseUri`] if the base URI has not been set.
+    /// Returns [`BuilderError::InvalidToken`] if the configured authentication token cannot be
+    /// encoded as an HTTP header value.
     pub fn discovery<ResBody>(self) -> std::result::Result<Discovery, BuilderError>
     where
         Conn: hyper_util::client::legacy::connect::Connect + Clone + Send + Sync + 'static,
@@ -183,6 +215,7 @@ impl<Conn, Layers> ClientBuilder<Conn, Layers> {
 pub struct Client {
     pub(crate) base_uri: http::Uri,
     pub(crate) timeout: Option<Duration>,
+    pub(crate) auth: Option<http::HeaderValue>,
     pub(crate) http: HttpService,
 }
 
@@ -293,7 +326,12 @@ impl Client {
     /// Send an HTTP request and return the response body bytes.
     ///
     /// Returns an [`Error::ApiError`] if the server responds with a non-success status.
-    pub(crate) async fn request(&self, req: http::Request<Full<Bytes>>) -> Result<Bytes> {
+    pub(crate) async fn request(&self, mut req: http::Request<Full<Bytes>>) -> Result<Bytes> {
+        if let Some(auth) = &self.auth {
+            req.headers_mut()
+                .insert(http::header::AUTHORIZATION, auth.clone());
+        }
+
         let request = async {
             let resp = self
                 .http

--- a/opensovd-client/src/discovery.rs
+++ b/opensovd-client/src/discovery.rs
@@ -81,6 +81,7 @@ impl Discovery {
         Ok(Client {
             base_uri: advertised.parse()?,
             timeout: self.inner.timeout,
+            auth: self.inner.auth.clone(),
             http: self.inner.http.clone(),
         })
     }

--- a/opensovd-client/src/lib.rs
+++ b/opensovd-client/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::missing_errors_doc)]
 #![doc = include_str!("../README.md")]
 
+mod auth;
 mod client;
 mod data;
 mod discovery;
@@ -13,6 +14,7 @@ mod list;
 #[cfg(unix)]
 mod unix;
 
+pub use auth::Auth;
 pub use client::{BuilderError, Client, ClientBuilder};
 pub use discovery::Discovery;
 pub use error::{Error, Result};

--- a/opensovd-client/tests/auth.rs
+++ b/opensovd-client/tests/auth.rs
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use mock_http_connector::Connector;
+use opensovd_client::{Auth, BuilderError, Client, SovdInfo};
+use serde_json::json;
+
+type Request = http::Request<String>;
+
+#[tokio::test]
+async fn client_sends_bearer_authorization_header() {
+    let mut builder = Connector::builder();
+    builder
+        .expect()
+        .with_uri("http://localhost/sovd/v1/components")
+        .returning(|req: Request| async move {
+            let authorization = req
+                .headers()
+                .get(http::header::AUTHORIZATION)
+                .expect("authorization header present");
+            assert_eq!(authorization, "Bearer test-token");
+            json!({"items": []}).to_string()
+        })
+        .unwrap();
+
+    let client = Client::builder()
+        .base_uri("http://localhost/sovd/v1")
+        .expect("valid URI")
+        .auth(Auth::bearer("test-token"))
+        .connector(builder.build())
+        .build()
+        .expect("valid test client");
+
+    let result = client.list_components().send().await.unwrap();
+    assert!(result.data.items.is_empty());
+}
+
+#[tokio::test]
+async fn discovery_selected_client_inherits_authorization_header() {
+    let mut builder = Connector::builder();
+    builder
+        .expect()
+        .with_uri("http://localhost/sovd/version-info")
+        .returning(|req: Request| async move {
+            let authorization = req
+                .headers()
+                .get(http::header::AUTHORIZATION)
+                .expect("authorization header present");
+            assert_eq!(authorization, "Bearer inherited-token");
+            json!({"sovd_info": [{
+                "version": "1.1",
+                "base_uri": "http://localhost/sovd/v1"
+            }]})
+            .to_string()
+        })
+        .unwrap();
+    builder
+        .expect()
+        .with_uri("http://localhost/sovd/v1/components")
+        .returning(|req: Request| async move {
+            let authorization = req
+                .headers()
+                .get(http::header::AUTHORIZATION)
+                .expect("authorization header present");
+            assert_eq!(authorization, "Bearer inherited-token");
+            json!({"items": []}).to_string()
+        })
+        .unwrap();
+
+    let client = Client::builder()
+        .base_uri("http://localhost/sovd")
+        .expect("valid URI")
+        .auth(Auth::bearer("inherited-token"))
+        .connector(builder.build())
+        .discovery()
+        .expect("valid discovery client")
+        .select(|s: &SovdInfo<serde_json::Value>| s.version == "1.1")
+        .await
+        .unwrap();
+
+    let result = client.list_components().send().await.unwrap();
+    assert!(result.data.items.is_empty());
+}
+
+#[test]
+fn build_rejects_invalid_bearer_token() {
+    let result = Client::builder()
+        .base_uri("http://localhost/sovd/v1")
+        .expect("valid URI")
+        .auth(Auth::bearer("bad\ntoken"))
+        .build();
+
+    assert!(matches!(result, Err(BuilderError::InvalidToken)));
+}


### PR DESCRIPTION
## Summary
- Introduced ClientBuilder::auth(...) and Auth::bearer(...) for configuring bearer token authentication.
- Validated bearer token header values during build(), returning BuilderError::InvalidToken for invalid tokens.
- Added a public Auth API with a non-exhaustive Bearer variant and redacted Debug output.

## Checklist
- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
Issue: eclipse-opensovd/opensovd-core#124