### PR TITLE
ci(labeler): cover all crates and python files

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -14,6 +14,22 @@ crate:server:
   - changed-files:
       - any-glob-to-any-file: opensovd-server/**
 
+crate:client:
+  - changed-files:
+      - any-glob-to-any-file: opensovd-client/**
+
+crate:providers:
+  - changed-files:
+      - any-glob-to-any-file: opensovd-providers/**
+
+crate:extra:
+  - changed-files:
+      - any-glob-to-any-file: opensovd-extra/**
+
+crate:mocks:
+  - changed-files:
+      - any-glob-to-any-file: opensovd-mocks/**
+
 crate:cli:
   - changed-files:
       - any-glob-to-any-file: opensovd-cli/**
@@ -44,13 +60,14 @@ tests:
   - changed-files:
       - any-glob-to-any-file:
           - tests/**
+          - opensovd-e2e/**
           - "**/tests/**/*.rs"
 
 docs:
   - changed-files:
       - any-glob-to-any-file:
           - docs/**
-          - "*.md"
+          - "**/*.md"
 
 docker:
   - changed-files:
@@ -62,3 +79,10 @@ docker:
 scripts:
   - changed-files:
       - any-glob-to-any-file: scripts/**
+
+python:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.py"
+          - "**/pyproject.toml"
+          - uv.lock


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

The labeler config was missing several parts of the workspace. This PR adds
crate labels for opensovd-client, opensovd-providers, opensovd-extra and
opensovd-mocks, includes opensovd-e2e in the tests label, extends the docs
label to markdown files in subdirectories, and adds a python label for
python sources and project files.

## Checklist

- [x] I have tested my changes locally
