### PR TITLE
fix(ci): unblock the advisories job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,27 +155,12 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      security-events: write
     steps:
       - uses: actions/checkout@v7
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-deny@${{ env.CARGO_DENY_VERSION }}
-
-      - name: Check advisories (SARIF)
-        if: needs.prepare.outputs.release == 'nightly' || needs.prepare.outputs.release == 'latest'
-        run: cargo deny --format sarif check advisories > advisories.sarif || true
-
-      - name: Upload SARIF
-        if: (needs.prepare.outputs.release == 'nightly' || needs.prepare.outputs.release == 'latest') && github.repository_owner == 'eclipse-opensovd'
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: advisories.sarif
-          category: cargo-deny-advisories
-
-      - name: Check advisories
-        if: needs.prepare.outputs.release != 'nightly' && needs.prepare.outputs.release != 'latest'
-        run: cargo deny check advisories
+      - run: cargo deny check advisories
 
   lint:
     needs: prepare

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "strsim"

--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,6 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
-    "OpenSSL",
     "Unicode-3.0",
 ]
 confidence-threshold = 0.93

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,7 @@ targets = [
 
 [advisories]
 version = 2
+yanked = "deny"
 ignore = [
     # Unmaintained (not vulnerable) transitive dev-only dependency: paste via mock-http-connector
     { id = "RUSTSEC-2024-0436", reason = "unmaintained transitive dev-only dep (paste via mock-http-connector)" },


### PR DESCRIPTION
## Summary

The advisories job has been failing on main. cargo-deny flagged the yanked
`spin 0.10.0`, but its SARIF serializer emits that result with an empty
`locations` array, which GitHub code scanning rejects. The job failed at the
upload step rather than at the check, and `gate` failed with it.

This updates spin to 0.10.1 and drops the SARIF upload, since Dependabot
alerts are enabled and the GitHub Advisory Database ingests RustSec. Yanked
crates now fail instead of warning, and the unused `OpenSSL` license
allowance is removed.

## Checklist

- [x] I have tested my changes locally

## Related

Failing run: https://github.com/eclipse-opensovd/opensovd-core/actions/runs/29893332882
