### PR TITLE
feat(mcp): advertise output schema on list tools

### DIFF
--- a/opensovd-cli/mcp/Cargo.toml
+++ b/opensovd-cli/mcp/Cargo.toml
@@ -17,11 +17,10 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "help", "std", "usage"] }
 libcli = { workspace = true }
 opensovd-client = { workspace = true }
-opensovd-models = { workspace = true }
+opensovd-models = { workspace = true, features = ["jsonschema"] }
 tokio = { workspace = true, features = ["rt", "macros", "io-std", "io-util"] }
 tracing = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io", "macros"] }
-serde_json = { workspace = true }
 
 [dev-dependencies]
 mock-http-connector = { workspace = true, features = ["hyper_1"] }

--- a/opensovd-cli/mcp/src/main.rs
+++ b/opensovd-cli/mcp/src/main.rs
@@ -434,6 +434,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_components_includes_schema() -> TestResult {
+        let components = serde_json::to_string(&opensovd_models::Response {
+            data: opensovd_models::Items {
+                items: vec![entity("components", "ecu1", "Engine ECU")],
+            },
+            schema: Some(serde_json::json!({"type": "object"})),
+        })?;
+
+        let mut builder = mock_http_connector::Connector::builder();
+        builder
+            .expect()
+            .with_uri("http://localhost/sovd/v1/components?include-schema=true")
+            .returning(components)?;
+
+        let client = setup(mock_client(builder.build())).await;
+
+        let result = client
+            .call_tool(CallToolRequestParams::new("list_components"))
+            .await?;
+
+        let structured = result
+            .structured_content
+            .expect("expected structured content");
+        let schema = structured
+            .get("schema")
+            .expect("expected schema in tool output");
+        assert_eq!(schema["type"], "object");
+
+        client.cancel().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn list_areas_returns_json() -> TestResult {
         let areas = serde_json::to_string(&opensovd_models::Items {
             items: vec![entity("areas", "powertrain", "Powertrain")],

--- a/opensovd-cli/mcp/src/main.rs
+++ b/opensovd-cli/mcp/src/main.rs
@@ -415,14 +415,18 @@ mod tests {
                 .output_schema
                 .as_ref()
                 .unwrap_or_else(|| panic!("expected output schema for {name}"));
-            assert_eq!(schema["type"], "object", "{name}: root must be an object");
-            let properties = &schema["properties"];
+            assert_eq!(
+                schema.get("type").and_then(|t| t.as_str()),
+                Some("object"),
+                "{name}: root must be an object"
+            );
+            let properties = schema.get("properties");
             assert!(
-                properties.get("items").is_some(),
+                properties.is_some_and(|p| p.get("items").is_some()),
                 "{name}: expected items property"
             );
             assert!(
-                properties.get("schema").is_some(),
+                properties.is_some_and(|p| p.get("schema").is_some()),
                 "{name}: expected schema property"
             );
         }

--- a/opensovd-cli/mcp/src/main.rs
+++ b/opensovd-cli/mcp/src/main.rs
@@ -424,35 +424,6 @@ mod tests {
 
     #[tokio::test]
     async fn list_components_returns_json() -> TestResult {
-        let components = serde_json::to_string(&opensovd_models::Items {
-            items: vec![entity("components", "ecu1", "Engine ECU")],
-        })?;
-
-        let mut builder = mock_http_connector::Connector::builder();
-        builder
-            .expect()
-            .with_uri("http://localhost/sovd/v1/components?include-schema=true")
-            .returning(components)?;
-
-        let client = setup(mock_client(builder.build())).await;
-
-        let result = client
-            .call_tool(CallToolRequestParams::new("list_components"))
-            .await?;
-
-        let structured = result
-            .structured_content
-            .expect("expected structured content");
-        let text = serde_json::to_string(&structured)?;
-        assert!(text.contains("Engine ECU"), "expected component name");
-        assert!(text.contains("ecu1"), "expected component id");
-
-        client.cancel().await?;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn list_components_includes_schema() -> TestResult {
         let components = serde_json::to_string(&opensovd_models::Response {
             data: opensovd_models::Items {
                 items: vec![entity("components", "ecu1", "Engine ECU")],
@@ -475,6 +446,9 @@ mod tests {
         let structured = result
             .structured_content
             .expect("expected structured content");
+        let text = serde_json::to_string(&structured)?;
+        assert!(text.contains("Engine ECU"), "expected component name");
+        assert!(text.contains("ecu1"), "expected component id");
         let schema = structured
             .get("schema")
             .expect("expected schema in tool output");

--- a/opensovd-cli/mcp/src/main.rs
+++ b/opensovd-cli/mcp/src/main.rs
@@ -460,8 +460,11 @@ mod tests {
 
     #[tokio::test]
     async fn list_areas_returns_json() -> TestResult {
-        let areas = serde_json::to_string(&opensovd_models::Items {
-            items: vec![entity("areas", "powertrain", "Powertrain")],
+        let areas = serde_json::to_string(&opensovd_models::Response {
+            data: opensovd_models::Items {
+                items: vec![entity("areas", "powertrain", "Powertrain")],
+            },
+            schema: Some(serde_json::json!({"type": "object"})),
         })?;
 
         let mut builder = mock_http_connector::Connector::builder();
@@ -482,6 +485,10 @@ mod tests {
         let text = serde_json::to_string(&structured)?;
         assert!(text.contains("Powertrain"), "expected area name");
         assert!(text.contains("powertrain"), "expected area id");
+        let schema = structured
+            .get("schema")
+            .expect("expected schema in tool output");
+        assert_eq!(schema["type"], "object");
 
         client.cancel().await?;
         Ok(())
@@ -489,8 +496,11 @@ mod tests {
 
     #[tokio::test]
     async fn list_apps_returns_json() -> TestResult {
-        let apps = serde_json::to_string(&opensovd_models::Items {
-            items: vec![entity("apps", "diag_app", "Diagnostic App")],
+        let apps = serde_json::to_string(&opensovd_models::Response {
+            data: opensovd_models::Items {
+                items: vec![entity("apps", "diag_app", "Diagnostic App")],
+            },
+            schema: Some(serde_json::json!({"type": "object"})),
         })?;
 
         let mut builder = mock_http_connector::Connector::builder();
@@ -511,6 +521,10 @@ mod tests {
         let text = serde_json::to_string(&structured)?;
         assert!(text.contains("Diagnostic App"), "expected app name");
         assert!(text.contains("diag_app"), "expected app id");
+        let schema = structured
+            .get("schema")
+            .expect("expected schema in tool output");
+        assert_eq!(schema["type"], "object");
 
         client.cancel().await?;
         Ok(())

--- a/opensovd-cli/mcp/src/main.rs
+++ b/opensovd-cli/mcp/src/main.rs
@@ -8,14 +8,14 @@ use std::process::ExitCode;
 
 use clap::Parser;
 use opensovd_client::Client;
+use opensovd_models::{Response, discovery::Entities};
 use rmcp::{
-    RoleServer, ServerHandler, ServiceExt,
+    Json, RoleServer, ServerHandler, ServiceExt,
     handler::server::{router::prompt::PromptRouter, tool::ToolRouter},
     model::{
-        CallToolResult, ErrorData as McpError, GetPromptResult, Implementation,
-        ListResourcesResult, PaginatedRequestParams, PromptMessage, ReadResourceRequestParams,
-        ReadResourceResponse, ReadResourceResult, Resource, ResourceContents, Role,
-        ServerCapabilities, ServerInfo,
+        ErrorData as McpError, GetPromptResult, Implementation, ListResourcesResult,
+        PaginatedRequestParams, PromptMessage, ReadResourceRequestParams, ReadResourceResponse,
+        ReadResourceResult, Resource, ResourceContents, Role, ServerCapabilities, ServerInfo,
     },
     prompt, prompt_handler, prompt_router,
     service::RequestContext,
@@ -36,7 +36,7 @@ struct McpServer {
 #[tool_router]
 impl McpServer {
     #[tool(description = "List all SOVD components")]
-    async fn list_components(&self) -> Result<CallToolResult, McpError> {
+    async fn list_components(&self) -> Result<Json<Response<Entities>>, McpError> {
         let response = self
             .client
             .list_components()
@@ -44,13 +44,11 @@ impl McpServer {
             .send()
             .await
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-        let value = serde_json::to_value(&response)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-        Ok(CallToolResult::structured(value))
+        Ok(Json(response))
     }
 
     #[tool(description = "List all SOVD areas")]
-    async fn list_areas(&self) -> Result<CallToolResult, McpError> {
+    async fn list_areas(&self) -> Result<Json<Response<Entities>>, McpError> {
         let response = self
             .client
             .list_areas()
@@ -58,13 +56,11 @@ impl McpServer {
             .send()
             .await
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-        let value = serde_json::to_value(&response)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-        Ok(CallToolResult::structured(value))
+        Ok(Json(response))
     }
 
     #[tool(description = "List all SOVD apps")]
-    async fn list_apps(&self) -> Result<CallToolResult, McpError> {
+    async fn list_apps(&self) -> Result<Json<Response<Entities>>, McpError> {
         let response = self
             .client
             .list_apps()
@@ -72,9 +68,7 @@ impl McpServer {
             .send()
             .await
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-        let value = serde_json::to_value(&response)
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
-        Ok(CallToolResult::structured(value))
+        Ok(Json(response))
     }
 }
 

--- a/opensovd-cli/mcp/src/main.rs
+++ b/opensovd-cli/mcp/src/main.rs
@@ -26,6 +26,11 @@ const TARGET: &str = "srv";
 
 const TOPOLOGY_URI: &str = "sovd://topology";
 
+#[allow(clippy::needless_pass_by_value)]
+fn internal(e: impl ToString) -> McpError {
+    McpError::internal_error(e.to_string(), None)
+}
+
 #[derive(Clone)]
 struct McpServer {
     tool_router: ToolRouter<Self>,
@@ -43,7 +48,7 @@ impl McpServer {
             .schema(true)
             .send()
             .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+            .map_err(internal)?;
         Ok(Json(response))
     }
 
@@ -55,7 +60,7 @@ impl McpServer {
             .schema(true)
             .send()
             .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+            .map_err(internal)?;
         Ok(Json(response))
     }
 
@@ -67,7 +72,7 @@ impl McpServer {
             .schema(true)
             .send()
             .await
-            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+            .map_err(internal)?;
         Ok(Json(response))
     }
 }
@@ -148,27 +153,9 @@ impl ServerHandler for McpServer {
         }
 
         let (components, areas, apps) = tokio::try_join!(
-            async {
-                self.client
-                    .list_components()
-                    .send()
-                    .await
-                    .map_err(|e| McpError::internal_error(e.to_string(), None))
-            },
-            async {
-                self.client
-                    .list_areas()
-                    .send()
-                    .await
-                    .map_err(|e| McpError::internal_error(e.to_string(), None))
-            },
-            async {
-                self.client
-                    .list_apps()
-                    .send()
-                    .await
-                    .map_err(|e| McpError::internal_error(e.to_string(), None))
-            },
+            async { self.client.list_components().send().await.map_err(internal) },
+            async { self.client.list_areas().send().await.map_err(internal) },
+            async { self.client.list_apps().send().await.map_err(internal) },
         )?;
 
         let mut text = String::new();

--- a/opensovd-cli/mcp/src/main.rs
+++ b/opensovd-cli/mcp/src/main.rs
@@ -399,6 +399,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_tools_advertise_output_schema() -> TestResult {
+        let connector = mock_http_connector::Connector::builder().build();
+        let client = setup(mock_client(connector)).await;
+
+        let tools = client.list_tools(Option::default()).await?;
+
+        for name in ["list_components", "list_areas", "list_apps"] {
+            let tool = tools
+                .tools
+                .iter()
+                .find(|t| t.name == name)
+                .unwrap_or_else(|| panic!("expected tool {name}"));
+            let schema = tool
+                .output_schema
+                .as_ref()
+                .unwrap_or_else(|| panic!("expected output schema for {name}"));
+            assert_eq!(schema["type"], "object", "{name}: root must be an object");
+            let properties = &schema["properties"];
+            assert!(
+                properties.get("items").is_some(),
+                "{name}: expected items property"
+            );
+            assert!(
+                properties.get("schema").is_some(),
+                "{name}: expected schema property"
+            );
+        }
+
+        client.cancel().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn list_components_returns_json() -> TestResult {
         let components = serde_json::to_string(&opensovd_models::Items {
             items: vec![entity("components", "ecu1", "Engine ECU")],

--- a/opensovd-models/src/lib.rs
+++ b/opensovd-models/src/lib.rs
@@ -29,9 +29,12 @@ pub struct Tag {
 
 /// Generic response wrapper with optional schema
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct Response<T> {
     #[serde(flatten)]
     pub data: T,
+    /// JSON Schema describing the payload, provided by the SOVD server
+    /// when `include-schema=true` is requested
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<serde_json::Value>,
 }


### PR DESCRIPTION
## Summary

The `list_components`, `list_areas` and `list_apps` MCP tools returned an
untyped `CallToolResult::structured` value, so clients had no way to learn the
shape of the structured output before calling a tool.

These tools now return `Json<Response<Entities>>`. rmcp derives the output
schema from the type and advertises it in `list_tools`, and the schema supplied
by the SOVD server travels with the payload. `Response` derives `JsonSchema`
behind the existing `jsonschema` feature of `opensovd-models`, which the mcp
crate now enables.

The repeated internal error mapping closures are folded into a shared helper.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated tests
