### PR TITLE
fix(deps): bump h2 to 0.4.18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,32 +31,53 @@ jobs:
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
       release: ${{ steps.check.outputs.release }}
+      channel: ${{ steps.check.outputs.channel }}
+      sha: ${{ steps.check.outputs.sha }}
     steps:
       - uses: actions/checkout@v7
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/v')
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - id: check
+        env:
+          EVENT: ${{ github.event_name }}
+          SHA: ${{ github.sha }}
         run: |
-          if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            LAST_SHA=$(git rev-parse nightly 2>/dev/null || echo "")
-            if [[ "$LAST_SHA" == "${{ github.sha }}" ]]; then
+          should_run=true
+          release=none
+          if [[ "$EVENT" == "schedule" ]]; then
+            if [[ "$(git rev-parse nightly 2>/dev/null || true)" == "$SHA" ]]; then
               echo "No changes since last nightly, skipping"
-              echo "should_run=false" >> "$GITHUB_OUTPUT"
-              echo "release=none" >> "$GITHUB_OUTPUT"
-              exit 0
+              should_run=false
+            else
+              release=nightly
             fi
-            echo "release=nightly" >> "$GITHUB_OUTPUT"
           elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            echo "release=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+            version=$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -1)
+            if [[ "$GITHUB_REF_NAME" != "v$version" ]]; then
+              echo "::error::tag $GITHUB_REF_NAME does not match workspace version $version"
+              exit 1
+            fi
+            release=$GITHUB_REF_NAME
           elif [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
-            echo "release=latest" >> "$GITHUB_OUTPUT"
-          else
-            echo "release=none" >> "$GITHUB_OUTPUT"
+            release=latest
           fi
-          echo "should_run=true" >> "$GITHUB_OUTPUT"
+
+          # The channel follows from the release type: only a version tag is stable.
+          case "$release" in
+            v*)      channel=stable ;;
+            nightly) channel=nightly ;;
+            *)       channel=dev ;;
+          esac
+
+          {
+            echo "should_run=$should_run"
+            echo "release=$release"
+            echo "channel=$channel"
+            echo "sha=${SHA::7}"
+          } >> "$GITHUB_OUTPUT"
 
   git-lint:
     if: github.event_name == 'pull_request'
@@ -74,6 +95,9 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+    env:
+      OPENSOVD_CHANNEL: ${{ needs.prepare.outputs.channel }}
+      OPENSOVD_COMMIT_SHA: ${{ needs.prepare.outputs.sha }}
     strategy:
       fail-fast: false
       matrix:
@@ -219,6 +243,11 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    # Runs the CLI version tests too, so it needs the same stamping as build:
+    # on a tag push git describe would otherwise report the tag, not a sha.
+    env:
+      OPENSOVD_CHANNEL: ${{ needs.prepare.outputs.channel }}
+      OPENSOVD_COMMIT_SHA: ${{ needs.prepare.outputs.sha }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -357,7 +386,7 @@ jobs:
 
       - run: |
           VERSION="${{ needs.prepare.outputs.release }}"
-          if [[ "$VERSION" == "nightly" || "$VERSION" == "latest" ]]; then
+          if [[ "${{ needs.prepare.outputs.channel }}" != "stable" ]]; then
             git cliff --unreleased -o CHANGELOG.md
           else
             git cliff --current -o CHANGELOG.md
@@ -386,7 +415,7 @@ jobs:
           subject-path: 'artifacts/release/*'
 
       - name: Delete existing prerelease
-        if: needs.prepare.outputs.release == 'nightly' || needs.prepare.outputs.release == 'latest'
+        if: needs.prepare.outputs.channel != 'stable'
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release delete "${{ needs.prepare.outputs.release }}" --yes --cleanup-tag || true
@@ -397,7 +426,7 @@ jobs:
           gh release create "${{ needs.prepare.outputs.release }}" \
             --title "${{ needs.prepare.outputs.release }}" \
             --notes-file CHANGELOG.md \
-            ${{ !startsWith(needs.prepare.outputs.release, 'v') && '--prerelease' || '' }} \
+            ${{ needs.prepare.outputs.channel != 'stable' && '--prerelease' || '' }} \
             artifacts/release/*
 
   gate:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1551,7 +1551,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1879,7 +1879,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2324,7 +2324,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,6 +930,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libcli-build"
+version = "0.1.1"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1214,7 @@ dependencies = [
  "clap",
  "http",
  "libcli",
+ "libcli-build",
  "opensovd-core",
  "opensovd-extra",
  "opensovd-mocks",
@@ -1215,7 +1223,6 @@ dependencies = [
  "schemars",
  "sd-notify",
  "serde",
- "time",
  "tokio",
  "tower",
  "tower-http",
@@ -1229,12 +1236,12 @@ dependencies = [
  "anyhow",
  "clap",
  "libcli",
+ "libcli-build",
  "mock-http-connector",
  "opensovd-client",
  "opensovd-models",
  "rmcp",
  "serde_json",
- "time",
  "tokio",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,9 +234,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [workspace]
-members = ["benches", "examples/client", "examples/server", "opensovd-mocks", "opensovd-client", "opensovd-core", "opensovd-extra", "opensovd-models", "opensovd-providers", "opensovd-server", "opensovd-cli/lib", "opensovd-cli/gateway", "opensovd-cli/mcp"]
+members = ["benches", "examples/client", "examples/server", "opensovd-mocks", "opensovd-client", "opensovd-core", "opensovd-extra", "opensovd-models", "opensovd-providers", "opensovd-server", "opensovd-cli/lib", "opensovd-cli/build", "opensovd-cli/gateway", "opensovd-cli/mcp"]
 resolver = "2"
 
 [workspace.package]
@@ -24,6 +24,7 @@ opensovd-client = { path = "opensovd-client" }
 opensovd-server = { path = "opensovd-server" }
 opensovd-mocks = { path = "opensovd-mocks" }
 libcli = { path = "opensovd-cli/lib" }
+libcli-build = { path = "opensovd-cli/build" }
 
 anyhow = { version = "1", default-features = false, features = ["std"] }
 async-trait = { version = "0.1", default-features = false }

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -42,11 +42,40 @@ The `prepare` job compares the current SHA with the `nightly` tag. If unchanged,
 
 ## Release Tags
 
-| Tag       | Trigger            | Description                                     |
-|-----------|--------------------|-------------------------------------------------|
-| `latest`  | Push to main       | Latest successful main branch build             |
-| `nightly` | Daily at 02:00 UTC | Scheduled nightly build (skipped if no changes) |
-| `vX.Y.Z`  | Tag push           | Versioned production release                    |
+| Tag       | Trigger            | Channel   | Description                                     |
+|-----------|--------------------|-----------|-------------------------------------------------|
+| `latest`  | Push to main       | `dev`     | Latest successful main branch build             |
+| `nightly` | Daily at 02:00 UTC | `nightly` | Scheduled nightly build (skipped if no changes) |
+| `vX.Y.Z`  | Tag push           | `stable`  | Versioned production release                    |
+
+## Release Channels
+
+The channel determines the version suffix the binaries report through `--version`,
+the SOVD vendor info and the MCP handshake. Only `stable` ships unsuffixed:
+
+| Channel   | Version string  | Built by                             |
+|-----------|-----------------|--------------------------------------|
+| `stable`  | `0.1.1`         | Tag push, after the tag is validated |
+| `nightly` | `0.1.1-nightly` | Scheduled build                      |
+| `dev`     | `0.1.1-dev`     | main, pull requests, local builds    |
+
+The suffixes are semver pre-releases, so `0.1.1-dev` sorts before `0.1.1-nightly`,
+which sorts before `0.1.1`.
+
+The `prepare` job derives the channel from the release type and passes it to
+`build`. Downstream jobs test `channel != 'stable'` wherever they need to know
+whether a build is a prerelease. Three environment variables feed the build scripts, all optional and all
+defaulting to a dev build stamped from the local git checkout:
+
+| Variable              | Purpose                                                          |
+|-----------------------|------------------------------------------------------------------|
+| `OPENSOVD_CHANNEL`    | Release channel; an unrecognised value fails the build            |
+| `OPENSOVD_COMMIT_SHA` | Revision to stamp, for builds without a git checkout              |
+| `SOURCE_DATE_EPOCH`   | Build date to stamp, for reproducible builds                      |
+
+On a tag push `prepare` verifies that the tag matches the workspace version and
+fails the run on a mismatch, so a `v0.2.0` tag cannot ship binaries reporting
+`0.1.1`.
 
 ## Docker Tags
 

--- a/opensovd-cli/build/Cargo.toml
+++ b/opensovd-cli/build/Cargo.toml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "libcli-build"
+version.workspace = true
+description = "Build-time version stamping for the OpenSOVD binaries"
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+time = { workspace = true, features = ["formatting", "macros"] }
+
+[lints]
+workspace = true

--- a/opensovd-cli/build/src/lib.rs
+++ b/opensovd-cli/build/src/lib.rs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Build-time version stamping shared by the OpenSOVD binaries.
+
+// Emitting directives on stdout is how a build script talks to cargo.
+#![allow(clippy::print_stdout)]
+
+use std::{path::Path, process::Command};
+
+use time::OffsetDateTime;
+
+/// Emits `VERSION`, `RELEASE_CHANNEL`, `COMMIT_SHA` and `BUILD_DATE` for the
+/// calling crate.
+///
+/// The revision and date are read from the environment first so builds without
+/// a git checkout (source tarballs, vendored trees) can still be stamped:
+/// `OPENSOVD_COMMIT_SHA` for the revision, `SOURCE_DATE_EPOCH` for the date.
+/// The release channel comes from `OPENSOVD_CHANNEL`, see [`channel_suffix`].
+pub fn emit() {
+    emit_version();
+    emit_commit_sha();
+    emit_build_date();
+}
+
+/// Maps a release channel onto its version suffix.
+///
+/// Only `stable` ships unsuffixed; every other channel is a semver pre-release,
+/// which orders `0.1.1-dev` before `0.1.1-nightly` before `0.1.1`.
+///
+/// # Panics
+///
+/// Panics on an unrecognised channel, failing the build rather than silently
+/// mislabelling a binary.
+fn channel_suffix(channel: &str) -> &'static str {
+    match channel {
+        "stable" => "",
+        "nightly" => "-nightly",
+        "dev" => "-dev",
+        other => panic!("unknown OPENSOVD_CHANNEL `{other}`, expected stable, nightly or dev"),
+    }
+}
+
+fn emit_version() {
+    println!("cargo::rerun-if-env-changed=OPENSOVD_CHANNEL");
+
+    // Anything not built by release infrastructure is a dev build.
+    let channel = std::env::var("OPENSOVD_CHANNEL")
+        .ok()
+        .filter(|channel| !channel.is_empty())
+        .unwrap_or_else(|| "dev".to_string());
+    let suffix = channel_suffix(&channel);
+
+    // Set by cargo for the crate being built, not for this one.
+    let Ok(version) = std::env::var("CARGO_PKG_VERSION") else {
+        panic!("CARGO_PKG_VERSION is unset; emit() must be called from a build script")
+    };
+
+    println!("cargo::rustc-env=RELEASE_CHANNEL={channel}");
+    println!("cargo::rustc-env=VERSION={version}{suffix}");
+}
+
+fn emit_commit_sha() {
+    println!("cargo::rerun-if-env-changed=OPENSOVD_COMMIT_SHA");
+
+    // Resolve the reflog via git: .git is a file, not a directory, in worktrees
+    // and submodules, so a hardcoded ../../.git/logs/HEAD does not exist there.
+    // A missing rerun-if-changed path makes cargo rebuild on every invocation.
+    if let Some(reflog) = git(["rev-parse", "--git-path", "logs/HEAD"])
+        && Path::new(&reflog).exists()
+    {
+        println!("cargo::rerun-if-changed={reflog}");
+    }
+
+    let sha = std::env::var("OPENSOVD_COMMIT_SHA")
+        .ok()
+        .filter(|sha| !sha.is_empty())
+        .or_else(|| git(["describe", "--dirty", "--always"]))
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo::rustc-env=COMMIT_SHA={sha}");
+}
+
+fn emit_build_date() {
+    println!("cargo::rerun-if-env-changed=SOURCE_DATE_EPOCH");
+
+    let epoch = std::env::var("SOURCE_DATE_EPOCH")
+        .ok()
+        .and_then(|ts| ts.parse::<i64>().ok())
+        .or_else(|| git(["log", "-1", "--pretty=%ct"]).and_then(|ts| ts.parse::<i64>().ok()));
+
+    let build_date = if let Some(epoch) = epoch
+        && let Ok(dt) = OffsetDateTime::from_unix_timestamp(epoch)
+    {
+        let format =
+            time::macros::format_description!("[year]-[month padding:zero]-[day padding:zero]");
+        dt.format(&format).unwrap_or_else(|_| "unknown".to_string())
+    } else {
+        "unknown".to_string()
+    };
+    println!("cargo::rustc-env=BUILD_DATE={build_date}");
+}
+
+/// Runs git in the crate being built, returning trimmed stdout on success.
+fn git<const N: usize>(args: [&str; N]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .and_then(|output| {
+            output
+                .status
+                .success()
+                .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        })
+        .filter(|out| !out.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::channel_suffix;
+
+    #[test]
+    fn stable_is_the_only_unsuffixed_channel() {
+        assert_eq!(channel_suffix("stable"), "");
+        assert_eq!(channel_suffix("nightly"), "-nightly");
+        assert_eq!(channel_suffix("dev"), "-dev");
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown OPENSOVD_CHANNEL")]
+    fn unknown_channel_fails_the_build() {
+        let _ = channel_suffix("beta");
+    }
+}

--- a/opensovd-cli/gateway/Cargo.toml
+++ b/opensovd-cli/gateway/Cargo.toml
@@ -46,7 +46,7 @@ rustls = { workspace = true, optional = true }
 sd-notify = { workspace = true }
 
 [build-dependencies]
-time = { workspace = true, features = ["formatting", "macros"] }
+libcli-build = { workspace = true }
 
 
 [lints]

--- a/opensovd-cli/gateway/build.rs
+++ b/opensovd-cli/gateway/build.rs
@@ -1,50 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use std::process::Command;
-
-use time::OffsetDateTime;
-
 fn main() {
-    // Set COMMIT_SHA from git describe
-    println!("cargo:rerun-if-changed=../../.git/logs/HEAD");
-    let sha = Command::new("git")
-        .args(["describe", "--dirty", "--always"])
-        .output()
-        .ok()
-        .and_then(|output| {
-            output
-                .status
-                .success()
-                .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
-        })
-        .unwrap_or_else(|| "unknown".to_string());
-    println!("cargo:rustc-env=COMMIT_SHA={sha}");
-
-    // Set BUILD_DATE from SOURCE_DATE_EPOCH or git commit timestamp
-    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
-    let timestamp = std::env::var("SOURCE_DATE_EPOCH").ok().or_else(|| {
-        Command::new("git")
-            .args(["log", "-1", "--pretty=%ct"])
-            .output()
-            .ok()
-            .and_then(|output| {
-                output
-                    .status
-                    .success()
-                    .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
-            })
-    });
-
-    let build_date = if let Some(ts) = timestamp
-        && let Ok(epoch) = ts.parse::<i64>()
-        && let Ok(dt) = OffsetDateTime::from_unix_timestamp(epoch)
-    {
-        let format =
-            time::macros::format_description!("[year]-[month padding:zero]-[day padding:zero]");
-        dt.format(&format).unwrap_or_else(|_| "unknown".to_string())
-    } else {
-        "unknown".to_string()
-    };
-    println!("cargo:rustc-env=BUILD_DATE={build_date}");
+    libcli_build::emit();
 }

--- a/opensovd-cli/gateway/src/cli.rs
+++ b/opensovd-cli/gateway/src/cli.rs
@@ -13,7 +13,7 @@ pub const ABOUT: &str = "OpenSOVD Gateway Server";
 const DEFAULT_URL: &str = "http://localhost:7690/sovd";
 
 const VERSION_STRING: &str = concat!(
-    env!("CARGO_PKG_VERSION"),
+    env!("VERSION"),
     " (",
     env!("COMMIT_SHA"),
     " ",

--- a/opensovd-cli/gateway/src/main.rs
+++ b/opensovd-cli/gateway/src/main.rs
@@ -31,7 +31,7 @@ struct OpenSovdInfo {
 const TARGET: &str = "gw";
 
 const VENDOR_INFO: OpenSovdInfo = OpenSovdInfo {
-    version: env!("CARGO_PKG_VERSION"),
+    version: env!("VERSION"),
     sha1: env!("COMMIT_SHA"),
     build_date: env!("BUILD_DATE"),
     name: "OpenSOVD",
@@ -59,6 +59,7 @@ async fn run(mut cli: cli::Cli) -> anyhow::Result<()> {
     tracing::info!(
         target: TARGET,
         version = %VENDOR_INFO.version,
+        channel = %env!("RELEASE_CHANNEL"),
         sha1 = %VENDOR_INFO.sha1,
         build_date = %VENDOR_INFO.build_date,
         "{}", cli::ABOUT);

--- a/opensovd-cli/mcp/Cargo.toml
+++ b/opensovd-cli/mcp/Cargo.toml
@@ -28,7 +28,7 @@ rmcp = { workspace = true, features = ["client", "transport-io"] }
 serde_json = { workspace = true }
 
 [build-dependencies]
-time = { workspace = true, features = ["formatting", "macros"] }
+libcli-build = { workspace = true }
 
 [lints]
 workspace = true

--- a/opensovd-cli/mcp/build.rs
+++ b/opensovd-cli/mcp/build.rs
@@ -1,50 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use std::process::Command;
-
-use time::OffsetDateTime;
-
 fn main() {
-    // Set COMMIT_SHA from git describe
-    println!("cargo:rerun-if-changed=../../.git/logs/HEAD");
-    let sha = Command::new("git")
-        .args(["describe", "--dirty", "--always"])
-        .output()
-        .ok()
-        .and_then(|output| {
-            output
-                .status
-                .success()
-                .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
-        })
-        .unwrap_or_else(|| "unknown".to_string());
-    println!("cargo:rustc-env=COMMIT_SHA={sha}");
-
-    // Set BUILD_DATE from SOURCE_DATE_EPOCH or git commit timestamp
-    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
-    let timestamp = std::env::var("SOURCE_DATE_EPOCH").ok().or_else(|| {
-        Command::new("git")
-            .args(["log", "-1", "--pretty=%ct"])
-            .output()
-            .ok()
-            .and_then(|output| {
-                output
-                    .status
-                    .success()
-                    .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
-            })
-    });
-
-    let build_date = if let Some(ts) = timestamp
-        && let Ok(epoch) = ts.parse::<i64>()
-        && let Ok(dt) = OffsetDateTime::from_unix_timestamp(epoch)
-    {
-        let format =
-            time::macros::format_description!("[year]-[month padding:zero]-[day padding:zero]");
-        dt.format(&format).unwrap_or_else(|_| "unknown".to_string())
-    } else {
-        "unknown".to_string()
-    };
-    println!("cargo:rustc-env=BUILD_DATE={build_date}");
+    libcli_build::emit();
 }

--- a/opensovd-cli/mcp/src/cli.rs
+++ b/opensovd-cli/mcp/src/cli.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 pub const ABOUT: &str = env!("CARGO_PKG_DESCRIPTION");
 
 const VERSION_STRING: &str = concat!(
-    env!("CARGO_PKG_VERSION"),
+    env!("VERSION"),
     " (",
     env!("COMMIT_SHA"),
     " ",

--- a/opensovd-cli/mcp/src/main.rs
+++ b/opensovd-cli/mcp/src/main.rs
@@ -115,7 +115,7 @@ impl ServerHandler for McpServer {
             .enable_resources()
             .enable_prompts()
             .build();
-        let server_info = Implementation::new("opensovd-mcp", env!("CARGO_PKG_VERSION"))
+        let server_info = Implementation::new("opensovd-mcp", env!("VERSION"))
             .with_description(env!("CARGO_PKG_DESCRIPTION"));
         ServerInfo::new(capabilities)
             .with_server_info(server_info)
@@ -215,7 +215,8 @@ async fn main() -> ExitCode {
 async fn serve(url: &str) -> anyhow::Result<()> {
     tracing::info!(
         target: TARGET,
-        version = %env!("CARGO_PKG_VERSION"),
+        version = %env!("VERSION"),
+        channel = %env!("RELEASE_CHANNEL"),
         sha1 = %env!("COMMIT_SHA"),
         build_date = %env!("BUILD_DATE"),
         "{}", cli::ABOUT

--- a/tests/opensovd-gateway/cli/test_version.py
+++ b/tests/opensovd-gateway/cli/test_version.py
@@ -7,9 +7,11 @@ import re
 
 import pytest
 
-# opensovd-gateway 0.1.1 (8ffa3f4-dirty 2025-12-16)
+# opensovd-gateway 0.1.1-dev (8ffa3f4-dirty 2025-12-16)
+# The channel suffix is absent on stable builds and present on every other channel.
 VERSION_PATTERN = re.compile(
-    r"opensovd-gateway (\d+\.\d+\.\d+) \(([a-f0-9]+(?:-dirty)?) (\d{4}-\d{2}-\d{2})\)"
+    r"opensovd-gateway (\d+\.\d+\.\d+(?:-(?:dev|nightly))?) "
+    r"\(([a-f0-9]+(?:-dirty)?) (\d{4}-\d{2}-\d{2})\)"
 )
 
 

--- a/tests/opensovd-mcp/cli/test_version.py
+++ b/tests/opensovd-mcp/cli/test_version.py
@@ -7,9 +7,11 @@ import re
 
 import pytest
 
-# opensovd-mcp 0.1.1 (8ffa3f4-dirty 2025-12-16)
+# opensovd-mcp 0.1.1-dev (8ffa3f4-dirty 2025-12-16)
+# The channel suffix is absent on stable builds and present on every other channel.
 VERSION_PATTERN = re.compile(
-    r"opensovd-mcp (\d+\.\d+\.\d+) \(([a-f0-9]+(?:-dirty)?) (\d{4}-\d{2}-\d{2})\)"
+    r"opensovd-mcp (\d+\.\d+\.\d+(?:-(?:dev|nightly))?) "
+    r"\(([a-f0-9]+(?:-dirty)?) (\d{4}-\d{2}-\d{2})\)"
 )
 
 


### PR DESCRIPTION
## Summary

Bumps h2 from 0.4.14 to 0.4.18 in Cargo.lock. h2 0.4.14 is flagged by
RUSTSEC-2026-0258 (unbounded queuing of empty DATA frames, patched in
0.4.16), which makes the advisories job fail on every pull request.

Verified locally with `cargo deny check advisories` and
`cargo check --locked --workspace`.

## Checklist

- [x] I have tested my changes locally

## Related

- Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0258