### PR TITLE
fix(server): derive advertised uris from the configured base uri

### DIFF
--- a/opensovd-cli/gateway/src/main.rs
+++ b/opensovd-cli/gateway/src/main.rs
@@ -121,7 +121,6 @@ where
         .url
         .parse()
         .with_context(|| format!("invalid --url {:?}", cli.url))?;
-    let base_uri = uri.path();
     let authority = uri
         .authority()
         .ok_or_else(|| {
@@ -173,7 +172,7 @@ where
     let server = builder
         .layer(libcli::trace::trace_layer())
         .layer(tower::util::option_layer(cors))
-        .base_uri(base_uri)?
+        .base_uri(uri)?
         .vendor_info(VENDOR_INFO)
         .build()?;
 

--- a/opensovd-server/src/routes/entities/app.rs
+++ b/opensovd-server/src/routes/entities/app.rs
@@ -202,7 +202,9 @@ mod tests {
             vendor_info: None,
             topology: create_mock_topology().await,
         };
-        let app = routes::<()>().with_state(state);
+        let app = routes::<()>()
+            .with_state(state)
+            .layer(crate::routes::test_base_uri());
 
         let request = Request::builder()
             .uri("/apps/engine_control")
@@ -237,7 +239,9 @@ mod tests {
             vendor_info: None,
             topology: create_mock_topology().await,
         };
-        let app = routes::<()>().with_state(state);
+        let app = routes::<()>()
+            .with_state(state)
+            .layer(crate::routes::test_base_uri());
 
         let request = Request::builder().uri("/apps").body(Body::empty()).unwrap();
 

--- a/opensovd-server/src/routes/entities/area.rs
+++ b/opensovd-server/src/routes/entities/area.rs
@@ -179,7 +179,9 @@ mod tests {
             vendor_info: None,
             topology: create_mock_topology().await,
         };
-        let app = routes::<()>().with_state(state);
+        let app = routes::<()>()
+            .with_state(state)
+            .layer(crate::routes::test_base_uri());
 
         let request = Request::builder()
             .uri("/areas/powertrain")
@@ -206,7 +208,9 @@ mod tests {
             vendor_info: None,
             topology: create_mock_topology().await,
         };
-        let app = routes::<()>().with_state(state);
+        let app = routes::<()>()
+            .with_state(state)
+            .layer(crate::routes::test_base_uri());
 
         let request = Request::builder()
             .uri("/areas")

--- a/opensovd-server/src/routes/entities/component.rs
+++ b/opensovd-server/src/routes/entities/component.rs
@@ -224,7 +224,9 @@ mod tests {
             vendor_info: None,
             topology: create_mock_topology().await,
         };
-        let app = routes::<()>().with_state(state);
+        let app = routes::<()>()
+            .with_state(state)
+            .layer(crate::routes::test_base_uri());
 
         let request = Request::builder()
             .uri("/components/ecu")
@@ -256,7 +258,9 @@ mod tests {
             vendor_info: None,
             topology: create_mock_topology().await,
         };
-        let app = routes::<()>().with_state(state);
+        let app = routes::<()>()
+            .with_state(state)
+            .layer(crate::routes::test_base_uri());
 
         let request = Request::builder()
             .uri("/components")

--- a/opensovd-server/src/routes/mod.rs
+++ b/opensovd-server/src/routes/mod.rs
@@ -25,7 +25,7 @@ mod entities;
 mod error;
 mod version;
 
-use axum::{Router, extract::FromRef, http::request::Parts};
+use axum::{Extension, Router, extract::FromRef, http::request::Parts};
 use http::header::HOST;
 use opensovd_core::Topology;
 pub use opensovd_models::version::{VendorInfo, VersionInfo};
@@ -50,20 +50,51 @@ const API_VERSION: &str = "v1";
 /// SOVD standard version.
 pub const SOVD_VERSION: &str = "1.1";
 
+/// Scheme and mount path the server advertises, resolved from its configuration
+/// and attached to every request as an extension.
+#[derive(Clone, Debug)]
+pub(crate) struct BaseUri {
+    pub scheme: String,
+    /// Normalized mount path: leading `/`, or empty when mounted at the root.
+    pub path: String,
+}
+
+impl Default for BaseUri {
+    fn default() -> Self {
+        Self {
+            scheme: "http".to_string(),
+            path: String::new(),
+        }
+    }
+}
+
+/// Mirrors the default gateway deployment for route tests.
+#[cfg(test)]
+pub(crate) fn test_base_uri() -> Extension<BaseUri> {
+    Extension(BaseUri {
+        scheme: "http".to_string(),
+        path: "/sovd".to_string(),
+    })
+}
+
 pub(crate) fn base_uri(parts: &Parts) -> String {
+    let (scheme, path) = parts
+        .extensions
+        .get::<BaseUri>()
+        .map_or(("http", ""), |b| (b.scheme.as_str(), b.path.as_str()));
     let host = parts
         .headers
         .get(HOST)
         .and_then(|h| h.to_str().ok())
         .unwrap_or("localhost");
-    format!("http://{host}/sovd")
+    format!("{scheme}://{host}{path}")
 }
 
 pub(crate) fn versioned_uri(parts: &Parts) -> String {
     format!("{}/{API_VERSION}", base_uri(parts))
 }
 
-pub fn router<V>(vendor_info: Option<V>, topology: Topology) -> Router
+pub fn router<V>(vendor_info: Option<V>, topology: Topology, base_uri: BaseUri) -> Router
 where
     V: Serialize + Clone + Send + Sync + 'static,
     VersionInfo<V>: JsonSchema,
@@ -81,5 +112,5 @@ where
         .nest(&format!("/{API_VERSION}"), v1_routes)
         .merge(version::routes::<V>());
 
-    router.with_state(state)
+    router.with_state(state).layer(Extension(base_uri))
 }

--- a/opensovd-server/src/routes/version.rs
+++ b/opensovd-server/src/routes/version.rs
@@ -88,6 +88,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_version_info_advertises_configured_base_uri() {
+        let state = AppState::<VendorInfo> {
+            vendor_info: None,
+            topology: Topology::default(),
+        };
+        let app = routes::<VendorInfo>()
+            .with_state(state)
+            .layer(axum::Extension(crate::routes::BaseUri {
+                scheme: "https".to_string(),
+                path: "/api/sovd".to_string(),
+            }));
+
+        let request = Request::builder()
+            .uri("/version-info")
+            .header("host", "vehicle.example:8443")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert!(response.status().is_success());
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(
+            json["sovd_info"][0]["base_uri"],
+            "https://vehicle.example:8443/api/sovd/v1"
+        );
+    }
+
+    #[tokio::test]
     async fn test_version_info_with_schema() {
         let state = AppState::<VendorInfo> {
             vendor_info: None,

--- a/opensovd-server/src/server.rs
+++ b/opensovd-server/src/server.rs
@@ -32,6 +32,14 @@ pub(crate) type Service = BoxCloneSyncService<
     std::convert::Infallible,
 >;
 
+/// Base URI as configured on the builder: the mount path, plus the scheme when
+/// one was supplied.
+#[derive(Clone, Default)]
+struct BaseConfig {
+    path: String,
+    scheme: Option<String>,
+}
+
 fn normalize_base(base: &str) -> Option<String> {
     match base.as_bytes() {
         b"" | b"/" => None,
@@ -96,6 +104,7 @@ impl From<UnixListener> for Listener {
 #[allow(clippy::too_many_arguments)]
 fn build_router<Vendor, Authn, Authz, Layer>(
     base: Option<&str>,
+    advertised: crate::routes::BaseUri,
     vendor_info: Option<Vendor>,
     authenticator: Authn,
     authorizer: Authz,
@@ -116,7 +125,7 @@ where
         Into<std::convert::Infallible> + 'static,
     <Layer::Service as TowerService<http::Request<axum::body::Body>>>::Future: Send + 'static,
 {
-    let inner = crate::routes::router(vendor_info, topology);
+    let inner = crate::routes::router(vendor_info, topology, advertised);
     let mut router = match base {
         Some(path) => Router::new().nest(path, inner),
         None => Router::new().merge(inner),
@@ -143,7 +152,7 @@ type ShutdownFuture = Shared<Pin<Box<dyn Future<Output = ()> + Send>>>;
 #[must_use]
 pub struct ServerBuilder<Vendor = VendorInfo, Authn = NoAuth, Authz = AllowAll, Layer = Identity> {
     listener: Option<Listener>,
-    base: String,
+    base: BaseConfig,
     shutdown: ShutdownFuture,
     vendor_info: Option<Vendor>,
     authenticator: Authn,
@@ -158,7 +167,7 @@ pub struct ServerBuilder<Vendor = VendorInfo, Authn = NoAuth, Authz = AllowAll, 
 
 pub struct Server<Vendor = VendorInfo, Authn = NoAuth, Authz = AllowAll, Layer = Identity> {
     listener: Listener,
-    base: String,
+    base: BaseConfig,
     shutdown: ShutdownFuture,
     vendor_info: Option<Vendor>,
     authenticator: Authn,
@@ -195,7 +204,7 @@ impl ServerBuilder<VendorInfo, NoAuth, AllowAll, Identity> {
             Box::pin(default_shutdown_signal());
         Self {
             listener: None,
-            base: String::new(),
+            base: BaseConfig::default(),
             shutdown: shutdown.shared(),
             vendor_info: Some(VendorInfo {
                 version: env!("CARGO_PKG_VERSION").into(),
@@ -219,7 +228,10 @@ impl<Vendor, Authn, Authz, Layer> ServerBuilder<Vendor, Authn, Authz, Layer> {
         self
     }
 
-    /// Set the base URI path for all SOVD routes.
+    /// Set the base URI for all SOVD routes.
+    ///
+    /// The path determines where the routes are mounted. A scheme, if given, is
+    /// the one advertised in generated URIs; local TLS takes precedence over it.
     ///
     /// # Errors
     ///
@@ -229,7 +241,10 @@ impl<Vendor, Authn, Authz, Layer> ServerBuilder<Vendor, Authn, Authz, Layer> {
         uri: impl TryInto<http::Uri>,
     ) -> std::result::Result<Self, BuilderError> {
         let uri: http::Uri = uri.try_into().map_err(|_| BuilderError::InvalidUri)?;
-        self.base = uri.path().to_string();
+        self.base = BaseConfig {
+            path: uri.path().to_string(),
+            scheme: uri.scheme_str().map(str::to_string),
+        };
         Ok(self)
     }
 
@@ -481,7 +496,24 @@ where
     ///
     /// Returns an error if the server cannot be started.
     pub async fn serve(self) -> std::io::Result<()> {
-        let base = normalize_base(&self.base);
+        let base = normalize_base(&self.base.path);
+
+        // local TLS wins over a configured scheme, which in turn wins over http
+        #[cfg(feature = "tls")]
+        let is_tls = self.tls_config.is_some();
+        #[cfg(not(feature = "tls"))]
+        let is_tls = false;
+        let advertised = crate::routes::BaseUri {
+            scheme: if is_tls {
+                "https".to_string()
+            } else {
+                self.base
+                    .scheme
+                    .clone()
+                    .unwrap_or_else(|| "http".to_string())
+            },
+            path: base.clone().unwrap_or_default(),
+        };
 
         if !self.discovery_providers.is_empty() {
             let topology = self.topology.clone();
@@ -491,6 +523,7 @@ where
 
         let router = build_router(
             base.as_deref(),
+            advertised,
             self.vendor_info,
             self.authenticator,
             self.authorizer,

--- a/opensovd-server/tests/builder.rs
+++ b/opensovd-server/tests/builder.rs
@@ -13,18 +13,34 @@ use opensovd_core::{
 use opensovd_server::Server;
 use tokio::time::Duration;
 
-#[tokio::test]
-async fn test_base_path_slash() {
-    let server = common::TestServer::builder().base_uri("/").build().await;
+// not a #[test] fn, so the test-only unwrap allowance does not apply here
+#[allow(clippy::unwrap_used)]
+async fn advertised_base_uri(server: &common::TestServer, path: &str) -> String {
     let client = common::client();
-
     let request = Request::builder()
-        .uri(server.url("/version-info"))
+        .uri(server.url(path))
         .body(http_body_util::Empty::<bytes::Bytes>::new())
         .unwrap();
 
     let response = client.request(request).await.unwrap();
     assert!(response.status().is_success());
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    json["sovd_info"][0]["base_uri"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+#[tokio::test]
+async fn test_base_path_slash() {
+    let server = common::TestServer::builder().base_uri("/").build().await;
+
+    assert_eq!(
+        advertised_base_uri(&server, "/version-info").await,
+        format!("http://{}/v1", server.addr)
+    );
 }
 
 #[tokio::test]
@@ -33,15 +49,44 @@ async fn test_base_path_with_slash() {
         .base_uri("/sovd")
         .build()
         .await;
-    let client = common::client();
 
+    assert_eq!(
+        advertised_base_uri(&server, "/sovd/version-info").await,
+        format!("http://{}/sovd/v1", server.addr)
+    );
+}
+
+#[tokio::test]
+async fn test_non_default_base_path_is_advertised() {
+    let server = common::TestServer::builder()
+        .base_uri("/api/sovd")
+        .topology(opensovd_mocks::create_mock_topology().await)
+        .build()
+        .await;
+
+    assert_eq!(
+        advertised_base_uri(&server, "/api/sovd/version-info").await,
+        format!("http://{}/api/sovd/v1", server.addr)
+    );
+
+    // hrefs share the advertised prefix, so the links resolve
+    let client = common::client();
     let request = Request::builder()
-        .uri(server.url("/sovd/version-info"))
+        .uri(server.url("/api/sovd/v1/components"))
         .body(http_body_util::Empty::<bytes::Bytes>::new())
         .unwrap();
 
     let response = client.request(request).await.unwrap();
     assert!(response.status().is_success());
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let href = json["items"][0]["href"].as_str().unwrap();
+
+    assert!(
+        href.starts_with(&format!("http://{}/api/sovd/v1/components/", server.addr)),
+        "unexpected href {href}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Generated URIs were hardcoded to `format!("http://{host}/sovd")`, so a server
mounted on a different base path advertised a `base_uri` and `href`s that do not
resolve, and a TLS server advertised `http`. Both are now resolved at startup
from the configured base URI and the TLS config, and carried to the handlers in
a request extension. Precedence is local TLS, then the scheme of the configured
base URI, then `http`.

`ServerBuilder::base_uri` now takes the whole URI instead of only its path, so
it can read the scheme. A bare path still works and yields `http`.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated tests
- [ ] I have added or updated documentation

## Related

None.
