### PR TITLE
feat: bulk-data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -156,6 +157,7 @@ dependencies = [
  "form_urlencoded",
  "futures-core",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "http-body-util",
@@ -185,6 +187,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -239,7 +250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.0",
 ]
 
@@ -347,6 +358,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -395,6 +415,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +465,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +491,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -596,6 +645,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +747,30 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heck"
@@ -1016,6 +1099,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.9",
+ "version_check",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,6 +1389,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "bytes",
+ "chrono",
  "futures",
  "http",
  "http-body",
@@ -1309,6 +1410,7 @@ dependencies = [
  "tokio-rustls",
  "tower",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1495,7 +1597,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
- "spin",
+ "spin 0.12.2",
  "thiserror 2.0.20",
 ]
 
@@ -1752,6 +1854,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,6 +1931,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spin"
@@ -2149,6 +2268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2180,14 +2305,20 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,6 +1275,9 @@ name = "opensovd-examples-server"
 version = "0.1.1"
 dependencies = [
  "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
  "jsonwebtoken",
  "libcli",
  "opensovd-core",
@@ -1286,6 +1289,7 @@ dependencies = [
  "rustls",
  "sd-notify",
  "sysinfo",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,6 +1144,8 @@ name = "opensovd-core"
 version = "0.1.1"
 dependencies = [
  "async-trait",
+ "bytes",
+ "chrono",
  "futures-core",
  "indexmap",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,6 +1368,7 @@ dependencies = [
 name = "opensovd-models"
 version = "0.1.1"
 dependencies = [
+ "chrono",
  "schemars",
  "serde",
  "serde_json",
@@ -1396,7 +1397,6 @@ dependencies = [
  "axum",
  "axum-extra",
  "bytes",
- "chrono",
  "futures",
  "http",
  "http-body",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,9 @@ dependencies = [
 name = "opensovd-mocks"
 version = "0.1.1"
 dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
  "opensovd-core",
  "opensovd-models",
  "opensovd-providers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ rmcp = { version = "3.0.0" }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "tls12"] }
 rustls-pki-types = { version = "1", default-features = false, features = ["std"] }
 tokio-rustls = { version = "0.26", default-features = false }
+uuid = { version = "1" }
 
 [workspace.lints.rust]
 unused = { level = "deny", priority = -1 }

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -9,6 +9,10 @@ license.workspace = true
 publish = false
 
 [[example]]
+name = "bulkdata"
+path = "bulkdata/bulkdata.rs"
+
+[[example]]
 name = "simple"
 path = "simple/simple.rs"
 
@@ -31,6 +35,9 @@ tls = ["opensovd-server/tls", "dep:rustls"]
 
 [dependencies]
 async-trait = { workspace = true }
+bytes = { workspace = true }
+chrono = { workspace = true }
+futures = { workspace = true, features = ["std", "async-await"] }
 jsonwebtoken = { workspace = true }
 libcli = { workspace = true }
 opensovd-core = { workspace = true }
@@ -41,7 +48,8 @@ opensovd-providers = { workspace = true }
 opensovd-server = { workspace = true }
 rustls = { workspace = true, optional = true }
 sysinfo = { workspace = true }
-tokio = { workspace = true, features = ["net", "rt-multi-thread", "macros", "fs"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["net", "rt-multi-thread", "macros", "fs", "io-util"] }
 tracing = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/examples/server/bulkdata/README.md
+++ b/examples/server/bulkdata/README.md
@@ -1,0 +1,5 @@
+# Bulkdata example
+
+Example implementation of a bulk-data provider that uses the filesystem for
+storage. The `bulkdata.sh` client can be used to upload/download/list/delete
+bulk-data artifacts.

--- a/examples/server/bulkdata/bulkdata.rs
+++ b/examples/server/bulkdata/bulkdata.rs
@@ -246,18 +246,22 @@ impl BulkDataProvider for TempFsBulkDataProvider {
     ) -> std::result::Result<(), BulkDataError> {
         let _category_path = self.ensure_category_dir(category_id).await?;
         let path = self.data_path(category_id, data_id)?;
-        let mut file = tokio::fs::File::create(&path)
+        let temp_path = self.data_path(category_id, &format!("{data_id}.tmp"))?;
+        let mut file = tokio::fs::File::create(&temp_path)
             .await
             .map_err(|error| BulkDataError::Internal(error.to_string()))?;
 
         while let Some(chunk) = data.next().await {
             let chunk = chunk?;
-            file.write_all(&chunk)
-                .await
-                .map_err(|error| BulkDataError::Internal(error.to_string()))?;
+            if let Err(e) = file.write_all(&chunk).await {
+                let _ = tokio::fs::remove_file(&temp_path).await;
+                return Err(BulkDataError::Internal(e.to_string()));
+            }
         }
 
-        file.flush()
+        let _ = file.flush().await;
+        drop(file);
+        tokio::fs::rename(&temp_path, &path)
             .await
             .map_err(|error| BulkDataError::Internal(error.to_string()))?;
 

--- a/examples/server/bulkdata/bulkdata.rs
+++ b/examples/server/bulkdata/bulkdata.rs
@@ -1,0 +1,329 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::expect_used)]
+
+//! Bulk-data example backed by a temporary filesystem directory.
+//!
+//! Starts a server on port 7690 with a single app-scoped bulk-data provider at
+//! `/sovd/v1/apps/bulkdata-example/bulk-data`.
+//!
+//! Categories are mapped to directories under a temporary root. The example
+//! starts empty and creates category directories on first upload.
+//!
+//! Run with: `cargo run -p opensovd-examples-server --example bulkdata`
+
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use futures::{Stream, StreamExt, stream};
+use opensovd_core::{
+    App, BulkData, BulkDataError, BulkDataMetadata, BulkDataProvider, CategoryFilter, CategoryInfo,
+    Component,
+};
+use opensovd_server::{Server, Topology};
+use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+const COMPONENT_ID: &str = "bulkdata-host";
+const APP_ID: &str = "bulkdata-example";
+const DEFAULT_MIMETYPE: &str = "application/octet-stream";
+const STREAM_CHUNK_SIZE: usize = 64 * 1024;
+
+#[derive(Debug)]
+struct TempFsBulkDataProvider {
+    root: TempDir,
+}
+
+impl TempFsBulkDataProvider {
+    fn validate_segment(kind: &str, value: &str) -> std::result::Result<(), BulkDataError> {
+        if value.is_empty()
+            || value == "."
+            || value == ".."
+            || value.contains('/')
+            || value.contains('\\')
+        {
+            return Err(BulkDataError::InvalidRequest(format!(
+                "invalid {kind}: {value}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn category_path(&self, category_id: &str) -> std::result::Result<PathBuf, BulkDataError> {
+        Self::validate_segment("category", category_id)?;
+        Ok(self.root.path().join(category_id))
+    }
+
+    fn data_path(
+        &self,
+        category_id: &str,
+        data_id: &str,
+    ) -> std::result::Result<PathBuf, BulkDataError> {
+        Self::validate_segment("data id", data_id)?;
+        Ok(self.category_path(category_id)?.join(data_id))
+    }
+
+    async fn ensure_category_dir(
+        &self,
+        category_id: &str,
+    ) -> std::result::Result<PathBuf, BulkDataError> {
+        let category_path = self.category_path(category_id)?;
+        tokio::fs::create_dir_all(&category_path)
+            .await
+            .map_err(|error| BulkDataError::Internal(error.to_string()))?;
+        Ok(category_path)
+    }
+
+    fn timestamp_string(time: SystemTime) -> String {
+        let timestamp: DateTime<Utc> = time.into();
+        timestamp.to_rfc3339()
+    }
+
+    fn include_metadata(metadata: &BulkDataMetadata, filter: &CategoryFilter) -> bool {
+        if filter.tags.as_ref().is_some_and(|tags| !tags.is_empty()) {
+            return false;
+        }
+
+        let created = metadata
+            .creation_date
+            .as_ref()
+            .and_then(|value| value.parse::<DateTime<Utc>>().ok());
+
+        if let Some(created_before) = filter.created_before
+            && created.is_some_and(|created_at| created_at >= created_before)
+        {
+            return false;
+        }
+
+        if let Some(created_after) = filter.created_after
+            && created.is_some_and(|created_at| created_at <= created_after)
+        {
+            return false;
+        }
+
+        true
+    }
+
+    async fn file_metadata(
+        &self,
+        entry: &tokio::fs::DirEntry,
+    ) -> std::result::Result<Option<BulkDataMetadata>, BulkDataError> {
+        let file_type = entry
+            .file_type()
+            .await
+            .map_err(|error| BulkDataError::Internal(error.to_string()))?;
+        if !file_type.is_file() {
+            return Ok(None);
+        }
+
+        let data_id = entry.file_name().to_string_lossy().to_string();
+        let stats = entry
+            .metadata()
+            .await
+            .map_err(|error| BulkDataError::Internal(error.to_string()))?;
+
+        let creation_date = stats.created().ok().map(Self::timestamp_string);
+        let last_modified = stats.modified().ok().map(Self::timestamp_string);
+
+        Ok(Some(BulkDataMetadata {
+            id: data_id.clone(),
+            mimetype: DEFAULT_MIMETYPE.to_string(),
+            name: Some(data_id),
+            translation_id: None,
+            size: Some(stats.len()),
+            creation_date,
+            last_modified,
+            hash: None,
+            hash_algorithm: None,
+            tags: None,
+        }))
+    }
+}
+
+#[async_trait]
+impl BulkDataProvider for TempFsBulkDataProvider {
+    async fn categories(&self) -> std::result::Result<Vec<CategoryInfo>, BulkDataError> {
+        let mut entries = tokio::fs::read_dir(self.root.path())
+            .await
+            .map_err(|error| BulkDataError::Internal(error.to_string()))?;
+        let mut categories = Vec::new();
+
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|error| BulkDataError::Internal(error.to_string()))?
+        {
+            let file_type = entry
+                .file_type()
+                .await
+                .map_err(|error| BulkDataError::Internal(error.to_string()))?;
+            if file_type.is_dir() {
+                categories.push(CategoryInfo {
+                    category: entry.file_name().to_string_lossy().to_string(),
+                    translation_id: None,
+                });
+            }
+        }
+
+        categories.sort_by(|left, right| left.category.cmp(&right.category));
+        Ok(categories)
+    }
+
+    async fn list(
+        &self,
+        category_id: &str,
+        filter: CategoryFilter,
+    ) -> std::result::Result<Vec<BulkDataMetadata>, BulkDataError> {
+        let category_path = self.category_path(category_id)?;
+        let mut entries = match tokio::fs::read_dir(&category_path).await {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(BulkDataError::Internal(error.to_string())),
+        };
+        let mut items = Vec::new();
+
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|error| BulkDataError::Internal(error.to_string()))?
+        {
+            if let Some(metadata) = self.file_metadata(&entry).await?
+                && Self::include_metadata(&metadata, &filter)
+            {
+                items.push(metadata);
+            }
+        }
+
+        items.sort_by(|left, right| left.id.cmp(&right.id));
+        Ok(items)
+    }
+
+    async fn download(
+        &self,
+        category_id: &str,
+        data_id: &str,
+    ) -> std::result::Result<BulkData, BulkDataError> {
+        let path = self.data_path(category_id, data_id)?;
+        let file = tokio::fs::File::open(&path).await.map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                BulkDataError::NotFound(format!("bulk data not found: {category_id}/{data_id}"))
+            } else {
+                BulkDataError::Internal(error.to_string())
+            }
+        })?;
+
+        let read_stream = stream::try_unfold(file, |mut file| async move {
+            let mut buffer = vec![0u8; STREAM_CHUNK_SIZE];
+            let bytes_read = file.read(&mut buffer).await?;
+            if bytes_read == 0 {
+                return Ok(None);
+            }
+            buffer.truncate(bytes_read);
+            Ok(Some((Bytes::from(buffer), file)))
+        })
+        .map(|result| {
+            result.map_err(|error: std::io::Error| BulkDataError::Internal(error.to_string()))
+        });
+
+        Ok(BulkData {
+            signature: None,
+            data: Box::new(Box::pin(read_stream)),
+        })
+    }
+
+    async fn upload(
+        &self,
+        category_id: &str,
+        data_id: &str,
+        _size: u64,
+        data: &mut (dyn Stream<Item = std::result::Result<Bytes, BulkDataError>> + Send + Unpin),
+        _signature: Option<&String>,
+    ) -> std::result::Result<(), BulkDataError> {
+        let _category_path = self.ensure_category_dir(category_id).await?;
+        let path = self.data_path(category_id, data_id)?;
+        let mut file = tokio::fs::File::create(&path)
+            .await
+            .map_err(|error| BulkDataError::Internal(error.to_string()))?;
+
+        while let Some(chunk) = data.next().await {
+            let chunk = chunk?;
+            file.write_all(&chunk)
+                .await
+                .map_err(|error| BulkDataError::Internal(error.to_string()))?;
+        }
+
+        file.flush()
+            .await
+            .map_err(|error| BulkDataError::Internal(error.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn delete(
+        &self,
+        category_id: &str,
+        data_id: Option<&str>,
+    ) -> std::result::Result<(), BulkDataError> {
+        if let Some(data_id) = data_id {
+            let path = self.data_path(category_id, data_id)?;
+            tokio::fs::remove_file(&path).await.map_err(|error| {
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    BulkDataError::DeletionFailed(format!(
+                        "bulk data not found: {category_id}/{data_id}"
+                    ))
+                } else {
+                    BulkDataError::DeletionFailed(error.to_string())
+                }
+            })?;
+        } else {
+            let category_path = self.category_path(category_id)?;
+            if let Err(error) = tokio::fs::remove_dir_all(&category_path).await
+                && error.kind() != std::io::ErrorKind::NotFound
+            {
+                return Err(BulkDataError::DeletionFailed(error.to_string()));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    libcli::init_tracing("info", None)?;
+
+    let root = tempfile::tempdir()?;
+    let root_path = root.path().display().to_string();
+    let provider = TempFsBulkDataProvider { root };
+
+    let component = Component::new(COMPONENT_ID, "Bulkdata Host");
+    let app = App::new(APP_ID, "Filesystem Bulkdata Example", COMPONENT_ID)
+        .with_bulkdata_provider(provider);
+
+    let topology = Topology::new();
+    {
+        let mut topology_guard = topology.write().await;
+        topology_guard.add_component(component);
+        topology_guard.add_app(app);
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:7690").await?;
+    let server = Server::builder()
+        .base_uri("http://127.0.0.1:7690/sovd")?
+        .listener(listener)
+        .topology(topology)
+        .layer(libcli::trace::trace_layer())
+        .build()?;
+
+    tracing::info!(
+        root_path,
+        app_id = APP_ID,
+        "Bulkdata example server running"
+    );
+    server.serve().await?;
+    Ok(())
+}

--- a/examples/server/bulkdata/bulkdata.rs
+++ b/examples/server/bulkdata/bulkdata.rs
@@ -14,7 +14,6 @@
 //! Run with: `cargo run -p opensovd-examples-server --example bulkdata`
 
 use std::path::PathBuf;
-use std::time::SystemTime;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -79,29 +78,25 @@ impl TempFsBulkDataProvider {
         Ok(category_path)
     }
 
-    fn timestamp_string(time: SystemTime) -> String {
-        let timestamp: DateTime<Utc> = time.into();
-        timestamp.to_rfc3339()
-    }
-
     fn include_metadata(metadata: &BulkDataMetadata, filter: &CategoryFilter) -> bool {
         if filter.tags.as_ref().is_some_and(|tags| !tags.is_empty()) {
             return false;
         }
 
-        let created = metadata
-            .creation_date
-            .as_ref()
-            .and_then(|value| value.parse::<DateTime<Utc>>().ok());
-
         if let Some(created_before) = filter.created_before
-            && created.is_some_and(|created_at| created_at >= created_before)
+            && metadata
+                .creation_date
+                .as_ref()
+                .is_some_and(|created_at| created_at >= &created_before)
         {
             return false;
         }
 
         if let Some(created_after) = filter.created_after
-            && created.is_some_and(|created_at| created_at <= created_after)
+            && metadata
+                .creation_date
+                .as_ref()
+                .is_some_and(|created_at| created_at <= &created_after)
         {
             return false;
         }
@@ -127,8 +122,8 @@ impl TempFsBulkDataProvider {
             .await
             .map_err(|error| BulkDataError::Internal(error.to_string()))?;
 
-        let creation_date = stats.created().ok().map(Self::timestamp_string);
-        let last_modified = stats.modified().ok().map(Self::timestamp_string);
+        let creation_date = stats.created().ok().map(Into::<DateTime<Utc>>::into);
+        let last_modified = stats.modified().ok().map(Into::<DateTime<Utc>>::into);
 
         Ok(Some(BulkDataMetadata {
             id: data_id.clone(),

--- a/examples/server/bulkdata/bulkdata.rs
+++ b/examples/server/bulkdata/bulkdata.rs
@@ -21,7 +21,7 @@ use chrono::{DateTime, Utc};
 use futures::{Stream, StreamExt, stream};
 use opensovd_core::{
     App, BulkData, BulkDataError, BulkDataMetadata, BulkDataProvider, CategoryFilter, CategoryInfo,
-    Component,
+    Component, DeletedBulkDataItem,
 };
 use opensovd_server::{Server, Topology};
 use tempfile::TempDir;
@@ -266,28 +266,47 @@ impl BulkDataProvider for TempFsBulkDataProvider {
     async fn delete(
         &self,
         category_id: &str,
-        data_id: Option<&str>,
+        data_id: &str,
     ) -> std::result::Result<(), BulkDataError> {
-        if let Some(data_id) = data_id {
-            let path = self.data_path(category_id, data_id)?;
-            tokio::fs::remove_file(&path).await.map_err(|error| {
-                if error.kind() == std::io::ErrorKind::NotFound {
-                    BulkDataError::DeletionFailed(format!(
-                        "bulk data not found: {category_id}/{data_id}"
-                    ))
-                } else {
-                    BulkDataError::DeletionFailed(error.to_string())
-                }
-            })?;
-        } else {
-            let category_path = self.category_path(category_id)?;
-            if let Err(error) = tokio::fs::remove_dir_all(&category_path).await
-                && error.kind() != std::io::ErrorKind::NotFound
-            {
-                return Err(BulkDataError::DeletionFailed(error.to_string()));
+        let path = self.data_path(category_id, data_id)?;
+        tokio::fs::remove_file(&path).await.map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                BulkDataError::DeletionFailed(format!(
+                    "bulk data not found: {category_id}/{data_id}"
+                ))
+            } else {
+                BulkDataError::DeletionFailed(error.to_string())
             }
-        }
+        })?;
         Ok(())
+    }
+
+    async fn delete_category(
+        &self,
+        category_id: &str,
+    ) -> Result<Vec<DeletedBulkDataItem>, BulkDataError> {
+        let category_path = self.category_path(category_id)?;
+        let mut items = Vec::new();
+        let mut no_errors = true;
+        for data in self.list(category_id, CategoryFilter::default()).await? {
+            let error = self.delete(category_id, &data.id).await.err();
+            if error.is_some() {
+                no_errors = false;
+            }
+            items.push(DeletedBulkDataItem { id: data.id, error });
+        }
+        if no_errors {
+            tokio::fs::remove_dir(&category_path)
+                .await
+                .map_err(|error| {
+                    if error.kind() == std::io::ErrorKind::NotFound {
+                        BulkDataError::DeletionFailed(format!("category not found: {category_id}"))
+                    } else {
+                        BulkDataError::DeletionFailed(error.to_string())
+                    }
+                })?;
+        }
+        Ok(items)
     }
 }
 

--- a/examples/server/bulkdata/bulkdata.sh
+++ b/examples/server/bulkdata/bulkdata.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+BASE_URL="${BULKDATA_BASE_URL:-http://127.0.0.1:7690/sovd/v1/apps/bulkdata-example/bulk-data}"
+
+usage() {
+	cat <<'EOF'
+Usage:
+  bulkdata.sh categories
+  bulkdata.sh files <category>
+  bulkdata.sh upload <category> <local-file> [remote-name]
+  bulkdata.sh download <category> <file-id> [output-path]
+  bulkdata.sh delete-file <category> <file-id>
+  bulkdata.sh delete-category <category>
+
+Environment:
+  BULKDATA_BASE_URL  Override the default bulkdata endpoint.
+
+Examples:
+  bulkdata.sh categories
+  bulkdata.sh files logs
+  bulkdata.sh upload logs ./demo.bin
+  bulkdata.sh download logs demo.bin ./downloaded-demo.bin
+  bulkdata.sh delete-file logs demo.bin
+  bulkdata.sh delete-category logs
+EOF
+}
+
+die() {
+	printf 'error: %s\n' "$1" >&2
+	exit 1
+}
+
+need_args() {
+	local expected="$1"
+	local actual="$2"
+	if [[ "$actual" -lt "$expected" ]]; then
+		usage
+		exit 1
+	fi
+}
+
+curl_json() {
+	curl --fail --silent --show-error "$@"
+	printf '\n'
+}
+
+command="${1:-}"
+
+if [[ -z "$command" ]]; then
+	usage
+	exit 1
+fi
+
+case "$command" in
+	categories|list-categories)
+		curl_json "$BASE_URL"
+		;;
+
+	files|list-files)
+		need_args 2 "$#"
+		category="$2"
+		curl_json "$BASE_URL/$category"
+		;;
+
+	upload)
+		need_args 3 "$#"
+		category="$2"
+		local_file="$3"
+		remote_name="${4:-$(basename "$local_file")}"
+
+		[[ -f "$local_file" ]] || die "file not found: $local_file"
+
+		curl_json \
+			-X POST \
+			-H "Content-Disposition: attachment; filename=\"$remote_name\"" \
+			-F "file=@${local_file};type=application/octet-stream" \
+			"$BASE_URL/$category"
+		;;
+
+	download)
+		need_args 3 "$#"
+		category="$2"
+		file_id="$3"
+		output_path="${4:-$file_id}"
+
+		curl --fail --silent --show-error \
+			"$BASE_URL/$category/$file_id" \
+			-o "$output_path"
+		printf 'saved %s\n' "$output_path"
+		;;
+
+	delete-file)
+		need_args 3 "$#"
+		category="$2"
+		file_id="$3"
+		curl --fail --silent --show-error \
+			-X DELETE \
+			"$BASE_URL/$category/$file_id"
+		printf 'deleted %s/%s\n' "$category" "$file_id"
+		;;
+
+	delete-category)
+		need_args 2 "$#"
+		category="$2"
+		curl --fail --silent --show-error \
+			-X DELETE \
+			"$BASE_URL/$category"
+		printf 'deleted category %s\n' "$category"
+		;;
+
+	-h|--help|help)
+		usage
+		;;
+
+	*)
+		die "unknown command: $command"
+		;;
+esac

--- a/opensovd-core/Cargo.toml
+++ b/opensovd-core/Cargo.toml
@@ -14,6 +14,8 @@ categories.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+bytes = { workspace = true }
+chrono = {workspace = true }
 futures-core = { workspace = true }
 indexmap = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }

--- a/opensovd-core/src/bulkdata.rs
+++ b/opensovd-core/src/bulkdata.rs
@@ -35,8 +35,8 @@ pub struct BulkDataMetadata {
     pub name: Option<String>,
     pub translation_id: Option<String>,
     pub size: Option<u64>,
-    pub creation_date: Option<String>,
-    pub last_modified: Option<String>,
+    pub creation_date: Option<DateTime<Utc>>,
+    pub last_modified: Option<DateTime<Utc>>,
     pub hash: Option<String>,
     pub hash_algorithm: Option<String>,
     pub tags: Option<Vec<String>>,
@@ -47,7 +47,7 @@ pub struct BulkData {
     pub data: Box<dyn Stream<Item = Result<Bytes>> + Send + Unpin>,
 }
 
-/// A `Result` alias where the `Err` variant is [`DataError`].
+/// A `Result` alias where the `Err` variant is [`BulkDataError`].
 pub type Result<T> = std::result::Result<T, BulkDataError>;
 
 #[async_trait]

--- a/opensovd-core/src/bulkdata.rs
+++ b/opensovd-core/src/bulkdata.rs
@@ -18,7 +18,7 @@ pub enum BulkDataError {
     DeletionFailed(String),
     #[error("{0}")]
     Internal(String),
-    #[error("bulk data upload failed: {0}")]
+    #[error("bulk data not found: {0}")]
     NotFound(String),
 }
 
@@ -66,7 +66,7 @@ pub trait BulkDataProvider: Send + Sync + std::fmt::Debug + 'static {
         &self,
         category_id: &str,
         data_id: &str,
-        size: u64,
+        size_upper_bound: u64,
         data: &mut (dyn Stream<Item = Result<Bytes>> + Send + Unpin),
         signature: Option<&String>,
     ) -> Result<()>;

--- a/opensovd-core/src/bulkdata.rs
+++ b/opensovd-core/src/bulkdata.rs
@@ -22,6 +22,7 @@ pub enum BulkDataError {
     NotFound(String),
 }
 
+#[derive(Debug, Default)]
 pub struct CategoryFilter {
     pub created_before: Option<DateTime<Utc>>,
     pub created_after: Option<DateTime<Utc>>,
@@ -50,6 +51,12 @@ pub struct BulkData {
 /// A `Result` alias where the `Err` variant is [`BulkDataError`].
 pub type Result<T> = std::result::Result<T, BulkDataError>;
 
+#[derive(Debug)]
+pub struct DeletedBulkDataItem {
+    pub id: String,
+    pub error: Option<BulkDataError>,
+}
+
 #[async_trait]
 pub trait BulkDataProvider: Send + Sync + std::fmt::Debug + 'static {
     async fn categories(&self) -> Result<Vec<CategoryInfo>>;
@@ -71,5 +78,7 @@ pub trait BulkDataProvider: Send + Sync + std::fmt::Debug + 'static {
         signature: Option<&String>,
     ) -> Result<()>;
 
-    async fn delete(&self, category_id: &str, data_id: Option<&str>) -> Result<()>;
+    async fn delete(&self, category_id: &str, data_id: &str) -> Result<()>;
+
+    async fn delete_category(&self, category_id: &str) -> Result<Vec<DeletedBulkDataItem>>;
 }

--- a/opensovd-core/src/bulkdata.rs
+++ b/opensovd-core/src/bulkdata.rs
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bulk-Data provider trait and types.
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use futures_core::Stream;
+
+use crate::CategoryInfo;
+
+#[derive(Debug, thiserror::Error)]
+pub enum BulkDataError {
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
+    #[error("bulk data deletion failed: {0}")]
+    DeletionFailed(String),
+    #[error("{0}")]
+    Internal(String),
+    #[error("bulk data upload failed: {0}")]
+    NotFound(String),
+}
+
+pub struct CategoryFilter {
+    pub created_before: Option<DateTime<Utc>>,
+    pub created_after: Option<DateTime<Utc>>,
+    pub tags: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BulkDataMetadata {
+    pub id: String,
+    pub mimetype: String,
+    pub name: Option<String>,
+    pub translation_id: Option<String>,
+    pub size: Option<u64>,
+    pub creation_date: Option<String>,
+    pub last_modified: Option<String>,
+    pub hash: Option<String>,
+    pub hash_algorithm: Option<String>,
+    pub tags: Option<Vec<String>>,
+}
+
+pub struct BulkData {
+    pub signature: Option<String>,
+    pub data: Box<dyn Stream<Item = Result<Bytes>> + Send + Unpin>,
+}
+
+/// A `Result` alias where the `Err` variant is [`DataError`].
+pub type Result<T> = std::result::Result<T, BulkDataError>;
+
+#[async_trait]
+pub trait BulkDataProvider: Send + Sync + std::fmt::Debug + 'static {
+    async fn categories(&self) -> Result<Vec<CategoryInfo>>;
+
+    async fn list(
+        &self,
+        category_id: &str,
+        filter: CategoryFilter,
+    ) -> Result<Vec<BulkDataMetadata>>;
+
+    async fn download(&self, category_id: &str, data_id: &str) -> Result<BulkData>;
+
+    async fn upload(
+        &self,
+        category_id: &str,
+        data_id: &str,
+        size: u64,
+        data: &mut (dyn Stream<Item = Result<Bytes>> + Send + Unpin),
+        signature: Option<&String>,
+    ) -> Result<()>;
+
+    async fn delete(&self, category_id: &str, data_id: Option<&str>) -> Result<()>;
+}

--- a/opensovd-core/src/entity/app.rs
+++ b/opensovd-core/src/entity/app.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
+use crate::bulkdata::BulkDataProvider;
 use crate::data::DataProvider;
 use crate::entity::EntityRef;
 
@@ -18,6 +19,7 @@ pub struct App {
     tags: Vec<String>,
     translation_id: Option<String>,
     data_provider: Option<Box<dyn DataProvider>>,
+    bulkdata_provider: Option<Box<dyn BulkDataProvider>>,
 }
 
 impl fmt::Debug for App {
@@ -31,6 +33,10 @@ impl fmt::Debug for App {
             .field("tags", &self.tags)
             .field("translation_id", &self.translation_id)
             .field("data_provider", &self.data_provider.as_ref().map(|_| "..."))
+            .field(
+                "bulkdata_provider",
+                &self.bulkdata_provider.as_ref().map(|_| "..."),
+            )
             .finish()
     }
 }
@@ -52,6 +58,7 @@ impl App {
             tags: Vec::new(),
             translation_id: None,
             data_provider: None,
+            bulkdata_provider: None,
         }
     }
 
@@ -76,6 +83,12 @@ impl App {
     #[must_use]
     pub fn with_data_provider(mut self, provider: impl DataProvider) -> Self {
         self.data_provider = Some(Box::new(provider));
+        self
+    }
+
+    #[must_use]
+    pub fn with_bulkdata_provider(mut self, provider: impl BulkDataProvider) -> Self {
+        self.bulkdata_provider = Some(Box::new(provider));
         self
     }
 
@@ -120,6 +133,11 @@ impl App {
     #[must_use]
     pub fn data_provider(&self) -> Option<&dyn DataProvider> {
         self.data_provider.as_deref()
+    }
+
+    #[must_use]
+    pub fn bulkdata_provider(&self) -> Option<&dyn BulkDataProvider> {
+        self.bulkdata_provider.as_deref()
     }
 
     #[must_use]

--- a/opensovd-core/src/entity/app.rs
+++ b/opensovd-core/src/entity/app.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::Arc;
 
 use crate::bulkdata::BulkDataProvider;
 use crate::data::DataProvider;
@@ -19,7 +20,7 @@ pub struct App {
     tags: Vec<String>,
     translation_id: Option<String>,
     data_provider: Option<Box<dyn DataProvider>>,
-    bulkdata_provider: Option<Box<dyn BulkDataProvider>>,
+    bulkdata_provider: Option<Arc<dyn BulkDataProvider>>,
 }
 
 impl fmt::Debug for App {
@@ -88,7 +89,7 @@ impl App {
 
     #[must_use]
     pub fn with_bulkdata_provider(mut self, provider: impl BulkDataProvider) -> Self {
-        self.bulkdata_provider = Some(Box::new(provider));
+        self.bulkdata_provider = Some(Arc::new(provider));
         self
     }
 
@@ -136,8 +137,8 @@ impl App {
     }
 
     #[must_use]
-    pub fn bulkdata_provider(&self) -> Option<&dyn BulkDataProvider> {
-        self.bulkdata_provider.as_deref()
+    pub fn bulkdata_provider(&self) -> Option<Arc<dyn BulkDataProvider>> {
+        self.bulkdata_provider.clone()
     }
 
     #[must_use]

--- a/opensovd-core/src/entity/component.rs
+++ b/opensovd-core/src/entity/component.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::Arc;
 
 use crate::bulkdata::BulkDataProvider;
 use crate::data::DataProvider;
@@ -18,7 +19,7 @@ pub struct Component {
     tags: Vec<String>,
     translation_id: Option<String>,
     data_provider: Option<Box<dyn DataProvider>>,
-    bulkdata_provider: Option<Box<dyn BulkDataProvider>>,
+    bulkdata_provider: Option<Arc<dyn BulkDataProvider>>,
 }
 
 impl fmt::Debug for Component {
@@ -80,7 +81,7 @@ impl Component {
 
     #[must_use]
     pub fn with_bulkdata_provider(mut self, provider: impl BulkDataProvider) -> Self {
-        self.bulkdata_provider = Some(Box::new(provider));
+        self.bulkdata_provider = Some(Arc::new(provider));
         self
     }
 
@@ -123,8 +124,8 @@ impl Component {
     }
 
     #[must_use]
-    pub fn bulkdata_provider(&self) -> Option<&dyn BulkDataProvider> {
-        self.bulkdata_provider.as_deref()
+    pub fn bulkdata_provider(&self) -> Option<Arc<dyn BulkDataProvider>> {
+        self.bulkdata_provider.clone()
     }
 
     #[must_use]

--- a/opensovd-core/src/entity/component.rs
+++ b/opensovd-core/src/entity/component.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
+use crate::bulkdata::BulkDataProvider;
 use crate::data::DataProvider;
 use crate::entity::EntityRef;
 
@@ -17,6 +18,7 @@ pub struct Component {
     tags: Vec<String>,
     translation_id: Option<String>,
     data_provider: Option<Box<dyn DataProvider>>,
+    bulkdata_provider: Option<Box<dyn BulkDataProvider>>,
 }
 
 impl fmt::Debug for Component {
@@ -29,6 +31,10 @@ impl fmt::Debug for Component {
             .field("tags", &self.tags)
             .field("translation_id", &self.translation_id)
             .field("data_provider", &self.data_provider.as_ref().map(|_| "..."))
+            .field(
+                "bulkdata_provider",
+                &self.bulkdata_provider.as_ref().map(|_| "..."),
+            )
             .finish()
     }
 }
@@ -44,6 +50,7 @@ impl Component {
             tags: Vec::new(),
             translation_id: None,
             data_provider: None,
+            bulkdata_provider: None,
         }
     }
 
@@ -68,6 +75,12 @@ impl Component {
     #[must_use]
     pub fn with_data_provider(mut self, provider: impl DataProvider) -> Self {
         self.data_provider = Some(Box::new(provider));
+        self
+    }
+
+    #[must_use]
+    pub fn with_bulkdata_provider(mut self, provider: impl BulkDataProvider) -> Self {
+        self.bulkdata_provider = Some(Box::new(provider));
         self
     }
 
@@ -107,6 +120,11 @@ impl Component {
     #[must_use]
     pub fn data_provider(&self) -> Option<&dyn DataProvider> {
         self.data_provider.as_deref()
+    }
+
+    #[must_use]
+    pub fn bulkdata_provider(&self) -> Option<&dyn BulkDataProvider> {
+        self.bulkdata_provider.as_deref()
     }
 
     #[must_use]

--- a/opensovd-core/src/lib.rs
+++ b/opensovd-core/src/lib.rs
@@ -5,11 +5,13 @@
 
 #![cfg_attr(all(test, coverage_nightly), feature(coverage_attribute))]
 
+mod bulkdata;
 mod data;
 mod discovery;
 mod entity;
 mod topology;
 
+pub use bulkdata::{BulkData, BulkDataError, BulkDataMetadata, BulkDataProvider, CategoryFilter};
 pub use data::{
     CategoryInfo, Data, DataError, DataFilter, DataProvider, DataScope, GroupInfo, Metadata,
     TagInfo,

--- a/opensovd-core/src/lib.rs
+++ b/opensovd-core/src/lib.rs
@@ -11,7 +11,10 @@ mod discovery;
 mod entity;
 mod topology;
 
-pub use bulkdata::{BulkData, BulkDataError, BulkDataMetadata, BulkDataProvider, CategoryFilter};
+pub use bulkdata::{
+    BulkData, BulkDataError, BulkDataMetadata, BulkDataProvider, CategoryFilter,
+    DeletedBulkDataItem,
+};
 pub use data::{
     CategoryInfo, Data, DataError, DataFilter, DataProvider, DataScope, GroupInfo, Metadata,
     TagInfo,

--- a/opensovd-mocks/Cargo.toml
+++ b/opensovd-mocks/Cargo.toml
@@ -14,6 +14,9 @@ categories.workspace = true
 publish = false
 
 [dependencies]
+async-trait = { workspace = true }
+bytes = { workspace = true }
+futures = { workspace = true, features = ["std", "async-await"] }
 opensovd-core = { workspace = true }
 opensovd-models = { workspace = true }
 opensovd-providers = { workspace = true }

--- a/opensovd-mocks/src/bulkdata.rs
+++ b/opensovd-mocks/src/bulkdata.rs
@@ -3,7 +3,7 @@
 
 //! In-memory bulk-data provider for tests.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
@@ -22,6 +22,37 @@ type BulkDataMap = HashMap<String, HashMap<String, Vec<u8>>>;
 #[derive(Clone, Default, Debug)]
 pub struct InMemoryBulkDataProvider {
     store: Arc<RwLock<BulkDataMap>>,
+    permanent: Arc<RwLock<HashSet<(String, String)>>>,
+}
+
+#[allow(clippy::unwrap_used)]
+impl InMemoryBulkDataProvider {
+    /// Adds an entry that is always present and can never be deleted.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal locks are poisoned.
+    #[must_use]
+    pub fn with_permanent_entry(self, category_id: &str, data_id: &str) -> Self {
+        self.store
+            .write()
+            .unwrap()
+            .entry(category_id.to_string())
+            .or_default()
+            .insert(data_id.to_string(), Vec::new());
+        self.permanent
+            .write()
+            .unwrap()
+            .insert((category_id.to_string(), data_id.to_string()));
+        self
+    }
+
+    fn is_permanent(&self, category_id: &str, data_id: &str) -> bool {
+        self.permanent
+            .read()
+            .unwrap()
+            .contains(&(category_id.to_string(), data_id.to_string()))
+    }
 }
 
 #[async_trait]
@@ -115,6 +146,12 @@ impl BulkDataProvider for InMemoryBulkDataProvider {
     }
 
     async fn delete(&self, category_id: &str, data_id: &str) -> Result<(), BulkDataError> {
+        if self.is_permanent(category_id, data_id) {
+            return Err(BulkDataError::DeletionFailed(format!(
+                "entry is protected: {category_id}/{data_id}"
+            )));
+        }
+
         let mut store = self.store.write().unwrap();
 
         store
@@ -128,16 +165,34 @@ impl BulkDataProvider for InMemoryBulkDataProvider {
         &self,
         category_id: &str,
     ) -> Result<Vec<DeletedBulkDataItem>, BulkDataError> {
+        let permanent = self.permanent.read().unwrap();
         let mut store = self.store.write().unwrap();
 
-        store
-            .remove(category_id)
-            .ok_or_else(|| BulkDataError::NotFound(format!("not found: {category_id}")))
-            .map(|items| {
-                items
-                    .into_keys()
-                    .map(|id| DeletedBulkDataItem { id, error: None })
-                    .collect()
-            })
+        let entries = store
+            .get_mut(category_id)
+            .ok_or_else(|| BulkDataError::NotFound(format!("not found: {category_id}")))?;
+
+        let ids: Vec<String> = entries.keys().cloned().collect();
+        let mut deleted = Vec::with_capacity(ids.len());
+        for id in ids {
+            if permanent.contains(&(category_id.to_string(), id.clone())) {
+                deleted.push(DeletedBulkDataItem {
+                    error: Some(BulkDataError::DeletionFailed(format!(
+                        "entry is protected: {category_id}/{id}"
+                    ))),
+                    id,
+                });
+            } else {
+                entries.remove(&id);
+                deleted.push(DeletedBulkDataItem { id, error: None });
+            }
+        }
+
+        if entries.is_empty() {
+            store.remove(category_id);
+        }
+
+        deleted.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(deleted)
     }
 }

--- a/opensovd-mocks/src/bulkdata.rs
+++ b/opensovd-mocks/src/bulkdata.rs
@@ -11,6 +11,7 @@ use bytes::Bytes;
 use futures::{Stream, StreamExt as _};
 use opensovd_core::{
     BulkData, BulkDataError, BulkDataMetadata, BulkDataProvider, CategoryFilter, CategoryInfo,
+    DeletedBulkDataItem,
 };
 
 type BulkDataMap = HashMap<String, HashMap<String, Vec<u8>>>;
@@ -113,15 +114,30 @@ impl BulkDataProvider for InMemoryBulkDataProvider {
         Ok(())
     }
 
-    async fn delete(&self, category_id: &str, data_id: Option<&str>) -> Result<(), BulkDataError> {
+    async fn delete(&self, category_id: &str, data_id: &str) -> Result<(), BulkDataError> {
         let mut store = self.store.write().unwrap();
-        if let Some(id) = data_id {
-            if let Some(cat) = store.get_mut(category_id) {
-                cat.remove(id);
-            }
-        } else {
-            store.remove(category_id);
-        }
-        Ok(())
+
+        store
+            .get_mut(category_id)
+            .and_then(|cat| cat.remove(data_id))
+            .ok_or_else(|| BulkDataError::NotFound(format!("not found: {category_id}/{data_id}")))
+            .map(|_| ())
+    }
+
+    async fn delete_category(
+        &self,
+        category_id: &str,
+    ) -> Result<Vec<DeletedBulkDataItem>, BulkDataError> {
+        let mut store = self.store.write().unwrap();
+
+        store
+            .remove(category_id)
+            .ok_or_else(|| BulkDataError::NotFound(format!("not found: {category_id}")))
+            .map(|items| {
+                items
+                    .into_keys()
+                    .map(|id| DeletedBulkDataItem { id, error: None })
+                    .collect()
+            })
     }
 }

--- a/opensovd-mocks/src/bulkdata.rs
+++ b/opensovd-mocks/src/bulkdata.rs
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-memory bulk-data provider for tests.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::{Stream, StreamExt as _};
+use opensovd_core::{
+    BulkData, BulkDataError, BulkDataMetadata, BulkDataProvider, CategoryFilter, CategoryInfo,
+};
+
+type BulkDataMap = HashMap<String, HashMap<String, Vec<u8>>>;
+
+/// In-memory BulkDataProvider for testing. Supports upload, download, list, and delete.
+///
+/// Storage layout: `category → (data_id → bytes)`.
+#[derive(Clone, Default, Debug)]
+pub struct InMemoryBulkDataProvider {
+    store: Arc<RwLock<BulkDataMap>>,
+}
+
+#[async_trait]
+#[allow(clippy::unwrap_used)]
+impl BulkDataProvider for InMemoryBulkDataProvider {
+    async fn categories(&self) -> Result<Vec<CategoryInfo>, BulkDataError> {
+        let store = self.store.read().unwrap();
+        let mut cats: Vec<CategoryInfo> = store
+            .keys()
+            .map(|k| CategoryInfo {
+                category: k.clone(),
+                translation_id: None,
+            })
+            .collect();
+        cats.sort_by(|a, b| a.category.cmp(&b.category));
+        Ok(cats)
+    }
+
+    async fn list(
+        &self,
+        category_id: &str,
+        filter: CategoryFilter,
+    ) -> Result<Vec<BulkDataMetadata>, BulkDataError> {
+        let store = self.store.read().unwrap();
+        let items = store
+            .get(category_id)
+            .map(|entries| {
+                let mut v: Vec<BulkDataMetadata> = entries
+                    .iter()
+                    .filter(|_| {
+                        // Tags filtering: skip item if filter requests non-empty tags
+                        filter.tags.as_ref().is_none_or(Vec::is_empty)
+                    })
+                    .map(|(id, data)| BulkDataMetadata {
+                        id: id.clone(),
+                        mimetype: "application/octet-stream".into(),
+                        name: Some(id.clone()),
+                        translation_id: None,
+                        size: Some(data.len() as u64),
+                        creation_date: None,
+                        last_modified: None,
+                        hash: None,
+                        hash_algorithm: None,
+                        tags: None,
+                    })
+                    .collect();
+                v.sort_by(|a, b| a.id.cmp(&b.id));
+                v
+            })
+            .unwrap_or_default();
+        Ok(items)
+    }
+
+    async fn download(&self, category_id: &str, data_id: &str) -> Result<BulkData, BulkDataError> {
+        let data = self
+            .store
+            .read()
+            .unwrap()
+            .get(category_id)
+            .and_then(|cat| cat.get(data_id))
+            .cloned()
+            .ok_or_else(|| {
+                BulkDataError::NotFound(format!("not found: {category_id}/{data_id}"))
+            })?;
+        let stream = futures::stream::iter(vec![Ok(Bytes::from(data))]);
+        Ok(BulkData {
+            signature: None,
+            data: Box::new(stream),
+        })
+    }
+
+    async fn upload(
+        &self,
+        category_id: &str,
+        data_id: &str,
+        _size: u64,
+        data: &mut (dyn Stream<Item = Result<Bytes, BulkDataError>> + Send + Unpin),
+        _signature: Option<&String>,
+    ) -> Result<(), BulkDataError> {
+        let mut buf = Vec::new();
+        while let Some(chunk) = data.next().await {
+            buf.extend_from_slice(&chunk?);
+        }
+        self.store
+            .write()
+            .unwrap()
+            .entry(category_id.to_string())
+            .or_default()
+            .insert(data_id.to_string(), buf);
+        Ok(())
+    }
+
+    async fn delete(&self, category_id: &str, data_id: Option<&str>) -> Result<(), BulkDataError> {
+        let mut store = self.store.write().unwrap();
+        if let Some(id) = data_id {
+            if let Some(cat) = store.get_mut(category_id) {
+                cat.remove(id);
+            }
+        } else {
+            store.remove(category_id);
+        }
+        Ok(())
+    }
+}

--- a/opensovd-mocks/src/lib.rs
+++ b/opensovd-mocks/src/lib.rs
@@ -9,6 +9,9 @@ use opensovd_core::{App, Area, Component, Topology};
 use opensovd_models::data::DataCategory;
 use opensovd_providers::data::{Constant, DataProviderBuilder};
 
+mod bulkdata;
+pub use bulkdata::InMemoryBulkDataProvider;
+
 /// Creates a mock topology with sample ECU, gateway, and app entities.
 ///
 /// # Panics
@@ -213,7 +216,8 @@ pub async fn create_mock_topology() -> Topology {
             "update_channel".to_string(),
             "stable".to_string(),
         )]))
-        .with_data_provider(ota_provider);
+        .with_data_provider(ota_provider)
+        .with_bulkdata_provider(InMemoryBulkDataProvider::default());
     // Note: NO with_area_id() - tests optional belongs-to
 
     // Areas

--- a/opensovd-mocks/src/lib.rs
+++ b/opensovd-mocks/src/lib.rs
@@ -217,7 +217,9 @@ pub async fn create_mock_topology() -> Topology {
             "stable".to_string(),
         )]))
         .with_data_provider(ota_provider)
-        .with_bulkdata_provider(InMemoryBulkDataProvider::default());
+        .with_bulkdata_provider(
+            InMemoryBulkDataProvider::default().with_permanent_entry("logs", "cannot_delete"),
+        );
     // Note: NO with_area_id() - tests optional belongs-to
 
     // Areas

--- a/opensovd-models/Cargo.toml
+++ b/opensovd-models/Cargo.toml
@@ -16,9 +16,10 @@ categories.workspace = true
 jsonschema = ["dep:schemars"]
 
 [dependencies]
-schemars = { workspace = true, optional = true, features = ["derive", "std"] }
+schemars = { workspace = true, optional = true, features = ["derive", "std", "chrono04"] }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
+chrono = { workspace = true, features = ["serde"] }
 
 [lints]
 workspace = true

--- a/opensovd-models/src/bulkdata.rs
+++ b/opensovd-models/src/bulkdata.rs
@@ -78,3 +78,134 @@ pub struct DeleteBulkDataResult {
     pub deleted_ids: Vec<String>,
     pub errors: Vec<GenericError>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ErrorCode, GenericError};
+
+    #[test]
+    fn bulk_data_descriptor_minimal_deserialize() {
+        let json = r#"{"id":"file1","mimetype":"application/octet-stream"}"#;
+        let desc: BulkDataDescriptor = serde_json::from_str(json).unwrap();
+        assert_eq!(desc.id, "file1");
+        assert_eq!(desc.mimetype, "application/octet-stream");
+        assert!(desc.name.is_none());
+        assert!(desc.translation_id.is_none());
+        assert!(desc.size.is_none());
+        assert!(desc.creation_date.is_none());
+        assert!(desc.last_modified.is_none());
+        assert!(desc.hash.is_none());
+        assert!(desc.hash_algorithm.is_none());
+        assert!(desc.tags.is_none());
+    }
+
+    #[test]
+    fn bulk_data_descriptor_full_serialize() {
+        let desc = BulkDataDescriptor {
+            id: "file2".into(),
+            mimetype: "image/png".into(),
+            name: Some("picture.png".into()),
+            translation_id: Some("t.id.1".into()),
+            size: Some(1024),
+            creation_date: Some("2026-01-01T00:00:00Z".into()),
+            last_modified: Some("2026-06-01T00:00:00Z".into()),
+            hash: Some("abc123".into()),
+            hash_algorithm: Some("sha256".into()),
+            tags: Some(SupportedTags(vec!["sensor".into(), "camera".into()])),
+        };
+        let json = serde_json::to_value(&desc).unwrap();
+        assert_eq!(json["id"], "file2");
+        assert_eq!(json["mimetype"], "image/png");
+        assert_eq!(json["name"], "picture.png");
+        assert_eq!(json["translation_id"], "t.id.1");
+        assert_eq!(json["size"], 1024);
+        assert_eq!(json["creation_date"], "2026-01-01T00:00:00Z");
+        assert_eq!(json["last_modified"], "2026-06-01T00:00:00Z");
+        assert_eq!(json["hash"], "abc123");
+        assert_eq!(json["hash_algorithm"], "sha256");
+        assert_eq!(json["tags"], serde_json::json!(["sensor", "camera"]));
+    }
+
+    #[test]
+    fn optional_fields_omitted_not_null() {
+        let desc = BulkDataDescriptor {
+            id: "f".into(),
+            mimetype: "application/octet-stream".into(),
+            name: None,
+            translation_id: None,
+            size: None,
+            creation_date: None,
+            last_modified: None,
+            hash: None,
+            hash_algorithm: None,
+            tags: None,
+        };
+        let json = serde_json::to_value(&desc).unwrap();
+        let obj = json.as_object().unwrap();
+        assert!(!obj.contains_key("name"));
+        assert!(!obj.contains_key("translation_id"));
+        assert!(!obj.contains_key("size"));
+        assert!(!obj.contains_key("creation_date"));
+        assert!(!obj.contains_key("last_modified"));
+        assert!(!obj.contains_key("hash"));
+        assert!(!obj.contains_key("hash_algorithm"));
+        assert!(!obj.contains_key("tags"));
+    }
+
+    #[test]
+    fn bulk_data_metadata_and_categories_empty_items() {
+        let metadata = BulkDataMetadata { items: vec![] };
+        let json = serde_json::to_value(&metadata).unwrap();
+        assert_eq!(json["items"], serde_json::json!([]));
+
+        let categories = AvailableBulkDataCategories { items: vec![] };
+        let json = serde_json::to_value(&categories).unwrap();
+        assert_eq!(json["items"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn delete_bulk_data_result_mixed_deleted_and_errors() {
+        let result = DeleteBulkDataResult {
+            deleted_ids: vec!["a".into(), "b".into()],
+            errors: vec![GenericError::new(
+                ErrorCode::ErrorResponse,
+                "could not delete c",
+            )],
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["deleted_ids"][0], "a");
+        assert_eq!(json["deleted_ids"][1], "b");
+        assert_eq!(json["errors"][0]["message"], "could not delete c");
+    }
+
+    #[test]
+    fn bulk_data_descriptors_query_kebab_case_deserialization() {
+        let json = r#"{
+            "include-schema": true,
+            "created-before": "2026-01-01T00:00:00Z",
+            "created-after": "2025-01-01T00:00:00Z",
+            "tags": ["sensor", "camera"]
+        }"#;
+        let query: BulkDataDescriptorsQuery = serde_json::from_str(json).unwrap();
+        assert!(query.include_schema);
+        assert_eq!(
+            query.created_before.as_deref(),
+            Some("2026-01-01T00:00:00Z")
+        );
+        assert_eq!(query.created_after.as_deref(), Some("2025-01-01T00:00:00Z"));
+        assert_eq!(
+            query.tags.as_deref(),
+            Some(&["sensor".to_string(), "camera".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn bulk_data_descriptors_query_all_defaults() {
+        let query = BulkDataDescriptorsQuery::default();
+        assert!(!query.include_schema);
+        assert!(query.created_before.is_none());
+        assert!(query.created_after.is_none());
+        assert!(query.tags.is_none());
+    }
+}

--- a/opensovd-models/src/bulkdata.rs
+++ b/opensovd-models/src/bulkdata.rs
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+use crate::{GenericError, types::SupportedTags};
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct BulkDataCategoriesQuery {
+    pub include_schema: bool,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct BulkDataDescriptorsQuery {
+    pub include_schema: bool,
+    pub created_before: Option<String>,
+    pub created_after: Option<String>,
+    pub tags: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct BulkDataCategory(pub String);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct BulkDataDescriptor {
+    pub id: String,
+    pub mimetype: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub translation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub creation_date: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_modified: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash_algorithm: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<SupportedTags>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct AvailableBulkDataCategories {
+    pub items: Vec<BulkDataCategory>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct BulkDataMetadata {
+    pub items: Vec<BulkDataDescriptor>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct BulkDataDownload {
+    pub signature: String,
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct BulkDataUpload {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct DeleteBulkDataResult {
+    pub deleted_ids: Vec<String>,
+    pub errors: Vec<GenericError>,
+}

--- a/opensovd-models/src/bulkdata.rs
+++ b/opensovd-models/src/bulkdata.rs
@@ -75,9 +75,16 @@ pub struct BulkDataUpload {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct DeleteBulkDataError {
+    pub id: String,
+    pub error: GenericError,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct DeleteBulkDataResult {
     pub deleted_ids: Vec<String>,
-    pub errors: Vec<GenericError>,
+    pub errors: Vec<DeleteBulkDataError>,
 }
 
 #[cfg(test)]
@@ -169,15 +176,16 @@ mod tests {
     fn delete_bulk_data_result_mixed_deleted_and_errors() {
         let result = DeleteBulkDataResult {
             deleted_ids: vec!["a".into(), "b".into()],
-            errors: vec![GenericError::new(
-                ErrorCode::ErrorResponse,
-                "could not delete c",
-            )],
+            errors: vec![DeleteBulkDataError {
+                id: "c".into(),
+                error: GenericError::new(ErrorCode::ErrorResponse, "could not delete c"),
+            }],
         };
         let json = serde_json::to_value(&result).unwrap();
         assert_eq!(json["deleted_ids"][0], "a");
         assert_eq!(json["deleted_ids"][1], "b");
-        assert_eq!(json["errors"][0]["message"], "could not delete c");
+        assert_eq!(json["errors"][0]["id"], "c");
+        assert_eq!(json["errors"][0]["error"]["message"], "could not delete c");
     }
 
     #[test]

--- a/opensovd-models/src/bulkdata.rs
+++ b/opensovd-models/src/bulkdata.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{GenericError, types::SupportedTags};
@@ -15,8 +16,8 @@ pub struct BulkDataCategoriesQuery {
 #[serde(default, rename_all = "kebab-case")]
 pub struct BulkDataDescriptorsQuery {
     pub include_schema: bool,
-    pub created_before: Option<String>,
-    pub created_after: Option<String>,
+    pub created_before: Option<DateTime<Utc>>,
+    pub created_after: Option<DateTime<Utc>>,
     pub tags: Option<Vec<String>>,
 }
 
@@ -36,9 +37,9 @@ pub struct BulkDataDescriptor {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub creation_date: Option<String>,
+    pub creation_date: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_modified: Option<String>,
+    pub last_modified: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hash: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -108,8 +109,8 @@ mod tests {
             name: Some("picture.png".into()),
             translation_id: Some("t.id.1".into()),
             size: Some(1024),
-            creation_date: Some("2026-01-01T00:00:00Z".into()),
-            last_modified: Some("2026-06-01T00:00:00Z".into()),
+            creation_date: Some("2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap()),
+            last_modified: Some("2026-06-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap()),
             hash: Some("abc123".into()),
             hash_algorithm: Some("sha256".into()),
             tags: Some(SupportedTags(vec!["sensor".into(), "camera".into()])),
@@ -190,10 +191,13 @@ mod tests {
         let query: BulkDataDescriptorsQuery = serde_json::from_str(json).unwrap();
         assert!(query.include_schema);
         assert_eq!(
-            query.created_before.as_deref(),
-            Some("2026-01-01T00:00:00Z")
+            query.created_before,
+            Some("2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap())
         );
-        assert_eq!(query.created_after.as_deref(), Some("2025-01-01T00:00:00Z"));
+        assert_eq!(
+            query.created_after,
+            Some("2025-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap())
+        );
         assert_eq!(
             query.tags.as_deref(),
             Some(&["sensor".to_string(), "camera".to_string()][..])

--- a/opensovd-models/src/lib.rs
+++ b/opensovd-models/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![cfg_attr(all(test, coverage_nightly), feature(coverage_attribute))]
 
+pub mod bulkdata;
 pub mod data;
 pub mod discovery;
 pub mod error;

--- a/opensovd-models/src/types.rs
+++ b/opensovd-models/src/types.rs
@@ -23,11 +23,21 @@ impl From<String> for JsonPointer {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SupportedTags(pub Vec<String>);
+
+impl From<Vec<String>> for SupportedTags {
+    fn from(v: Vec<String>) -> Self {
+        Self(v)
+    }
+}
+
 #[cfg(feature = "jsonschema")]
 mod schema {
     use schemars::{JsonSchema, Schema, SchemaGenerator};
 
-    use super::{JsonPointer, UriReference};
+    use super::{JsonPointer, SupportedTags, UriReference};
 
     impl JsonSchema for UriReference {
         fn schema_name() -> std::borrow::Cow<'static, str> {
@@ -51,6 +61,21 @@ mod schema {
             schemars::json_schema!({
                 "type": "string",
                 "format": "json-pointer"
+            })
+        }
+    }
+
+    impl JsonSchema for SupportedTags {
+        fn schema_name() -> std::borrow::Cow<'static, str> {
+            "SupportedTags".into()
+        }
+
+        fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+            schemars::json_schema!({
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
             })
         }
     }

--- a/opensovd-server/Cargo.toml
+++ b/opensovd-server/Cargo.toml
@@ -23,10 +23,11 @@ tls = ["dep:rustls", "dep:tokio-rustls"]
 opensovd-core = { workspace = true }
 opensovd-models = { workspace = true }
 schemars = { workspace = true, optional = true }
-axum = { workspace = true, features = ["json", "matched-path", "query", "tokio", "http1"] }
+axum = { workspace = true, features = ["json", "matched-path", "query", "tokio", "http1", "multipart"] }
 bytes = { workspace = true }
+chrono = { workspace = true }
 http-body = { workspace = true }
-axum-extra = { workspace = true, features = ["query", "with-rejection"] }
+axum-extra = { workspace = true, features = ["query", "with-rejection", "typed-header"] }
 futures = { workspace = true, features = ["std", "async-await"] }
 http = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -38,6 +39,7 @@ tower = { workspace = true, features = ["util"] }
 tracing = { workspace = true }
 rustls = { workspace = true, optional = true }
 tokio-rustls = { workspace = true, optional = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/opensovd-server/Cargo.toml
+++ b/opensovd-server/Cargo.toml
@@ -25,7 +25,6 @@ opensovd-models = { workspace = true }
 schemars = { workspace = true, optional = true }
 axum = { workspace = true, features = ["json", "matched-path", "query", "tokio", "http1", "multipart"] }
 bytes = { workspace = true }
-chrono = { workspace = true }
 http-body = { workspace = true }
 axum-extra = { workspace = true, features = ["query", "with-rejection", "typed-header"] }
 futures = { workspace = true, features = ["std", "async-await"] }

--- a/opensovd-server/src/routes/bulkdata.rs
+++ b/opensovd-server/src/routes/bulkdata.rs
@@ -90,30 +90,12 @@ async fn bulk_data_categories(
     }))
 }
 
-fn category_filter(query: &BulkDataDescriptorsQuery) -> Result<CategoryFilter> {
-    let created_before = query
-        .created_before
-        .as_ref()
-        .map(|date| {
-            date.parse::<chrono::DateTime<chrono::Utc>>()
-                .map_err(|e| BulkDataError::InvalidRequest(format!("Invalid date format: {e}")))
-        })
-        .transpose()?;
-
-    let created_after = query
-        .created_after
-        .as_ref()
-        .map(|date| {
-            date.parse::<chrono::DateTime<chrono::Utc>>()
-                .map_err(|e| BulkDataError::InvalidRequest(format!("Invalid date format: {e}")))
-        })
-        .transpose()?;
-
-    Ok(CategoryFilter {
-        created_before,
-        created_after,
+fn category_filter(query: &BulkDataDescriptorsQuery) -> CategoryFilter {
+    CategoryFilter {
+        created_before: query.created_before,
+        created_after: query.created_after,
         tags: query.tags.clone(),
-    })
+    }
 }
 
 async fn bulk_data_descriptors(
@@ -127,7 +109,7 @@ async fn bulk_data_descriptors(
     Ok(Json(Response {
         data: BulkDataMetadata {
             items: provider
-                .list(&category, category_filter(&query)?)
+                .list(&category, category_filter(&query))
                 .await?
                 .iter()
                 .map(|metadata| BulkDataDescriptor {
@@ -136,8 +118,8 @@ async fn bulk_data_descriptors(
                     name: metadata.name.clone(),
                     translation_id: metadata.translation_id.clone(),
                     size: metadata.size,
-                    creation_date: metadata.creation_date.clone(),
-                    last_modified: metadata.last_modified.clone(),
+                    creation_date: metadata.creation_date,
+                    last_modified: metadata.last_modified,
                     hash: metadata.hash.clone(),
                     hash_algorithm: metadata.hash_algorithm.clone(),
                     tags: metadata

--- a/opensovd-server/src/routes/bulkdata.rs
+++ b/opensovd-server/src/routes/bulkdata.rs
@@ -1,0 +1,380 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bulk-Data resource endpoints.
+//!
+//! Provides routes for:
+//! - GET /{entity-collection}/{entity-id}/bulk-data - List bulk-data categories
+//! - GET /{entity-collection}/{entity-id}/bulk-data/{category} - List of BulkDataDescriptors for a specific category
+//! - POST /{entity-collection}/{entity-id}/bulk-data/{category} - Upload bulk data to the SOVD server and create a resource for the bulk data
+//! - DELETE /{entity-collection}/{entity-id}/bulk-data/{category} - Delete all bulk data resources for a specific category
+//! - GET /{entity-collection}/{entity-id}/bulk-data/{category}/{bulk-data-id} - Download a specific bulk data resource
+//! - DELETE /{entity-collection}/{entity-id}/bulk-data/{category}/{bulk-data-id} - Delete a specific bulk data resource
+
+use axum::{
+    Json, Router,
+    body::Body,
+    extract::{DefaultBodyLimit, FromRequest, Multipart, Path, Request, State},
+    response::IntoResponse,
+    routing::get,
+};
+use axum_extra::{
+    TypedHeader,
+    extract::{Query, WithRejection},
+    headers::{ContentLength, ContentType, Header},
+};
+use futures::StreamExt;
+use http::{HeaderName, HeaderValue, StatusCode};
+use opensovd_core::{BulkDataError, BulkDataProvider, CategoryFilter, Topology, TopologyReadGuard};
+use opensovd_models::{
+    Response,
+    bulkdata::{
+        AvailableBulkDataCategories, BulkDataCategoriesQuery, BulkDataCategory, BulkDataDescriptor,
+        BulkDataDescriptorsQuery, BulkDataMetadata, BulkDataUpload,
+    },
+    types::SupportedTags,
+};
+
+use crate::routes::{
+    AppState,
+    error::{Error, Result},
+};
+use crate::schema::JsonSchema;
+
+// Maximum allowed size for bulk data uploads (1 GiB).
+const MAX_BULKDATA_BODY_BYTES: usize = 1024 * 1024 * 1024;
+
+pub fn routes<V>() -> Router<AppState<V>>
+where
+    V: Clone + Send + Sync + 'static,
+{
+    Router::new()
+        .route(
+            "/{entity-collection}/{entity-id}/bulk-data",
+            get(bulk_data_categories),
+        )
+        .route(
+            "/{entity-collection}/{entity-id}/bulk-data/{category}",
+            get(bulk_data_descriptors)
+                .post(upload_bulk_data)
+                .delete(delete_bulk_data_category),
+        )
+        .route(
+            "/{entity-collection}/{entity-id}/bulk-data/{category}/{bulk-data-id}",
+            get(download_bulk_data).delete(delete_bulk_data),
+        )
+        .layer(DefaultBodyLimit::max(MAX_BULKDATA_BODY_BYTES))
+}
+
+async fn bulk_data_categories(
+    State(topology): State<Topology>,
+    Path((entity_collection, entity_id)): Path<(String, String)>,
+    WithRejection(Query(query), _): WithRejection<Query<BulkDataCategoriesQuery>, Error>,
+) -> Result<Json<Response<AvailableBulkDataCategories>>> {
+    let topo = topology.read().await;
+    let provider = get_provider(&topo, &entity_collection, &entity_id)?;
+    Ok(Json(Response {
+        data: AvailableBulkDataCategories {
+            items: provider
+                .categories()
+                .await?
+                .iter()
+                .map(|c| BulkDataCategory(c.category.clone()))
+                .collect::<Vec<_>>(),
+        },
+        schema: query
+            .include_schema
+            .then_some(AvailableBulkDataCategories::schema()),
+    }))
+}
+
+fn category_filter(query: &BulkDataDescriptorsQuery) -> Result<CategoryFilter> {
+    let created_before = query
+        .created_before
+        .as_ref()
+        .map(|date| {
+            date.parse::<chrono::DateTime<chrono::Utc>>()
+                .map_err(|e| BulkDataError::InvalidRequest(format!("Invalid date format: {e}")))
+        })
+        .transpose()?;
+
+    let created_after = query
+        .created_after
+        .as_ref()
+        .map(|date| {
+            date.parse::<chrono::DateTime<chrono::Utc>>()
+                .map_err(|e| BulkDataError::InvalidRequest(format!("Invalid date format: {e}")))
+        })
+        .transpose()?;
+
+    Ok(CategoryFilter {
+        created_before,
+        created_after,
+        tags: query.tags.clone(),
+    })
+}
+
+async fn bulk_data_descriptors(
+    State(topology): State<Topology>,
+    Path((entity_collection, entity_id, category)): Path<(String, String, String)>,
+    WithRejection(Query(query), _): WithRejection<Query<BulkDataDescriptorsQuery>, Error>,
+) -> Result<Json<Response<BulkDataMetadata>>> {
+    let topo = topology.read().await;
+    let provider = get_provider(&topo, &entity_collection, &entity_id)?;
+
+    Ok(Json(Response {
+        data: BulkDataMetadata {
+            items: provider
+                .list(&category, category_filter(&query)?)
+                .await?
+                .iter()
+                .map(|metadata| BulkDataDescriptor {
+                    id: metadata.id.clone(),
+                    mimetype: metadata.mimetype.clone(),
+                    name: metadata.name.clone(),
+                    translation_id: metadata.translation_id.clone(),
+                    size: metadata.size,
+                    creation_date: metadata.creation_date.clone(),
+                    last_modified: metadata.last_modified.clone(),
+                    hash: metadata.hash.clone(),
+                    hash_algorithm: metadata.hash_algorithm.clone(),
+                    tags: metadata
+                        .tags
+                        .as_ref()
+                        .map(|tags| SupportedTags(tags.clone())),
+                })
+                .collect::<Vec<_>>(),
+        },
+        schema: query.include_schema.then_some(BulkDataMetadata::schema()),
+    }))
+}
+
+#[derive(Clone, Debug)]
+pub struct ContentDisposition {
+    _disposition_type: String,
+    filename: Option<String>,
+    name: Option<String>,
+}
+
+impl Header for ContentDisposition {
+    fn name() -> &'static HeaderName {
+        &::http::header::CONTENT_DISPOSITION
+    }
+
+    fn decode<'i, I: Iterator<Item = &'i HeaderValue>>(
+        values: &mut I,
+    ) -> std::result::Result<Self, axum_extra::headers::Error> {
+        values
+            .next()
+            .cloned()
+            .map(|hv| {
+                let s = hv
+                    .to_str()
+                    .map_err(|_| axum_extra::headers::Error::invalid())?;
+                let parts: Vec<&str> = s.split(';').collect();
+                let disposition_type = parts
+                    .first()
+                    .map(|s| s.trim().to_string())
+                    .unwrap_or_default();
+                let mut filename = None;
+                let mut name = None;
+                for part in parts.get(1..).unwrap_or(&[]) {
+                    let part = part.trim();
+                    if part.starts_with("filename=") {
+                        filename = Some(
+                            part.trim_start_matches("filename=")
+                                .trim_matches('"')
+                                .to_string(),
+                        );
+                    } else if part.starts_with("name=") {
+                        name = Some(
+                            part.trim_start_matches("name=")
+                                .trim_matches('"')
+                                .to_string(),
+                        );
+                    }
+                }
+                Ok(ContentDisposition {
+                    _disposition_type: disposition_type,
+                    filename,
+                    name,
+                })
+            })
+            .transpose()?
+            .ok_or_else(axum_extra::headers::Error::invalid)
+    }
+
+    fn encode<E: Extend<HeaderValue>>(&self, _values: &mut E) {
+        unimplemented!();
+    }
+}
+
+async fn upload_bulk_data(
+    State(topology): State<Topology>,
+    Path((entity_collection, entity_id, category)): Path<(String, String, String)>,
+    WithRejection(TypedHeader(content_type), _): WithRejection<TypedHeader<ContentType>, Error>,
+    WithRejection(TypedHeader(content_disposition), _): WithRejection<
+        TypedHeader<ContentDisposition>,
+        Error,
+    >,
+    WithRejection(TypedHeader(content_length), _): WithRejection<TypedHeader<ContentLength>, Error>,
+    req: Request,
+) -> Result<(StatusCode, Json<Response<BulkDataUpload>>)> {
+    let topo = topology.read().await;
+    let provider = get_provider(&topo, &entity_collection, &entity_id)?;
+
+    let filename = content_disposition
+        .filename
+        .clone()
+        .or_else(|| content_disposition.name.clone())
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    if content_type == ContentType::octet_stream() {
+        let mut stream = req
+            .into_body()
+            .into_data_stream()
+            .map(|r| r.map_err(|e| BulkDataError::Internal(e.to_string())));
+        provider
+            .upload(&category, &filename, content_length.0, &mut stream, None)
+            .await?;
+    } else {
+        let mut multipart = Multipart::from_request(req, &())
+            .await
+            .map_err(|e| BulkDataError::InvalidRequest(e.to_string()))?;
+        let mut sig = None;
+        while let Some(field) = multipart
+            .next_field()
+            .await
+            .map_err(|e| BulkDataError::InvalidRequest(e.to_string()))?
+        {
+            match field.content_type() {
+                Some("application/json") => {
+                    let json: serde_json::Value = serde_json::from_str(
+                        &field
+                            .text()
+                            .await
+                            .map_err(|e| BulkDataError::Internal(e.to_string()))?,
+                    )
+                    .map_err(|e| BulkDataError::InvalidRequest(e.to_string()))?;
+
+                    if let Some(signature) = json.get("signature").and_then(|s| s.as_str()) {
+                        sig = Some(signature.to_string());
+                    }
+                }
+                Some("application/octet-stream") => {
+                    let mut data_stream = field.map(|chunk| {
+                        chunk.map_err(|e| BulkDataError::InvalidRequest(e.to_string()))
+                    });
+                    provider
+                        .upload(
+                            &category,
+                            &filename,
+                            content_length.0,
+                            &mut data_stream,
+                            sig.as_ref(),
+                        )
+                        .await?;
+                }
+                _ => {
+                    return Err(BulkDataError::InvalidRequest(
+                        "unexpected content type".to_string(),
+                    )
+                    .into());
+                }
+            }
+        }
+    }
+
+    Ok((
+        StatusCode::CREATED,
+        Json(Response {
+            data: BulkDataUpload { id: entity_id },
+            schema: Some(Vec::<BulkDataUpload>::schema()),
+        }),
+    ))
+}
+
+async fn delete_bulk_data_category(
+    State(topology): State<Topology>,
+    Path((entity_collection, entity_id, category)): Path<(String, String, String)>,
+) -> Result<StatusCode> {
+    let topo = topology.read().await;
+    let provider = get_provider(&topo, &entity_collection, &entity_id)?;
+
+    provider.delete(&category, None).await?;
+
+    Ok(StatusCode::OK)
+}
+
+async fn download_bulk_data(
+    State(topology): State<Topology>,
+    Path((entity_collection, entity_id, category, bulk_data_id)): Path<(
+        String,
+        String,
+        String,
+        String,
+    )>,
+) -> Result<impl IntoResponse> {
+    let topo = topology.read().await;
+    let provider = get_provider(&topo, &entity_collection, &entity_id)?;
+
+    let bulkdata = provider.download(&category, &bulk_data_id).await?;
+
+    let mut response = axum::response::Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "application/octet-stream")
+        .header(
+            "Content-Disposition",
+            format!("attachment; filename=\"{bulk_data_id}\""),
+        );
+
+    if let Some(signature) = bulkdata.signature {
+        response = response.header("X-Signature", signature);
+    }
+
+    Ok(response
+        .body(Body::from_stream(bulkdata.data))
+        .map_err(|e| BulkDataError::Internal(e.to_string()))?)
+}
+
+async fn delete_bulk_data(
+    State(topology): State<Topology>,
+    Path((entity_collection, entity_id, category, bulk_data_id)): Path<(
+        String,
+        String,
+        String,
+        String,
+    )>,
+) -> Result<StatusCode> {
+    let topo = topology.read().await;
+    let provider = get_provider(&topo, &entity_collection, &entity_id)?;
+
+    provider.delete(&category, Some(&bulk_data_id)).await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+fn get_provider<'a>(
+    topo: &'a TopologyReadGuard<'a>,
+    entity_collection: &str,
+    entity_id: &str,
+) -> Result<&'a dyn BulkDataProvider> {
+    match entity_collection {
+        "components" => {
+            let component = topo
+                .get_component(entity_id)
+                .map_err(|_| Error::EntityNotFound(entity_id.to_string()))?;
+            component
+                .bulkdata_provider()
+                .ok_or_else(|| Error::ProviderNotAvailable("bulkdata".into()))
+        }
+        "apps" => {
+            let app = topo
+                .get_app(entity_id)
+                .map_err(|_| Error::EntityNotFound(entity_id.to_string()))?;
+            app.bulkdata_provider()
+                .ok_or_else(|| Error::ProviderNotAvailable("bulkdata".into()))
+        }
+        _ => Err(Error::EntityNotFound(entity_collection.to_string())),
+    }
+}

--- a/opensovd-server/src/routes/bulkdata.rs
+++ b/opensovd-server/src/routes/bulkdata.rs
@@ -11,7 +11,7 @@
 //! - GET /{entity-collection}/{entity-id}/bulk-data/{category}/{bulk-data-id} - Download a specific bulk data resource
 //! - DELETE /{entity-collection}/{entity-id}/bulk-data/{category}/{bulk-data-id} - Delete a specific bulk data resource
 
-use std::sync::Arc;
+use std::{sync::Arc, vec};
 
 use axum::{
     Json, Router,
@@ -29,10 +29,11 @@ use futures::StreamExt;
 use http::{HeaderMap, HeaderName, HeaderValue, StatusCode, request::Parts};
 use opensovd_core::{BulkDataError, BulkDataProvider, CategoryFilter, Topology, TopologyReadGuard};
 use opensovd_models::{
-    Response,
+    GenericError, Response,
     bulkdata::{
         AvailableBulkDataCategories, BulkDataCategoriesQuery, BulkDataCategory, BulkDataDescriptor,
-        BulkDataDescriptorsQuery, BulkDataMetadata, BulkDataUpload,
+        BulkDataDescriptorsQuery, BulkDataMetadata, BulkDataUpload, DeleteBulkDataError,
+        DeleteBulkDataResult,
     },
     types::SupportedTags,
 };
@@ -316,13 +317,30 @@ async fn upload_bulk_data(
 async fn delete_bulk_data_category(
     State(topology): State<Topology>,
     Path((entity_collection, entity_id, category)): Path<(String, String, String)>,
-) -> Result<StatusCode> {
+) -> Result<Json<Response<DeleteBulkDataResult>>> {
     let topo = topology.read().await;
     let provider = get_provider(topo, &entity_collection, &entity_id)?;
 
-    provider.delete(&category, None).await?;
+    let deleted = provider.delete_category(&category).await?;
+    let mut result = DeleteBulkDataResult {
+        deleted_ids: vec![],
+        errors: vec![],
+    };
+    for item in deleted {
+        if let Some(error) = item.error {
+            result.errors.push(DeleteBulkDataError {
+                id: item.id.clone(),
+                error: GenericError::with_vendor_code("unable-to-delete", error.to_string()),
+            });
+        } else {
+            result.deleted_ids.push(item.id.clone());
+        }
+    }
 
-    Ok(StatusCode::OK)
+    Ok(Json(Response {
+        data: result,
+        schema: None,
+    }))
 }
 
 async fn download_bulk_data(
@@ -368,7 +386,7 @@ async fn delete_bulk_data(
     let topo = topology.read().await;
     let provider = get_provider(topo, &entity_collection, &entity_id)?;
 
-    provider.delete(&category, Some(&bulk_data_id)).await?;
+    provider.delete(&category, &bulk_data_id).await?;
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/opensovd-server/src/routes/bulkdata.rs
+++ b/opensovd-server/src/routes/bulkdata.rs
@@ -39,7 +39,9 @@ use opensovd_models::{
 
 use crate::routes::{
     AppState,
+    entities::encode_path_segment,
     error::{Error, Result},
+    versioned_uri,
 };
 use crate::schema::JsonSchema;
 
@@ -208,7 +210,6 @@ async fn upload_bulk_data(
     let topo = topology.read().await;
     let provider = get_provider(topo, &entity_collection, &entity_id)?;
 
-    let base_uri = super::base_uri(&parts);
     let filename = content_disposition
         .filename
         .clone()
@@ -292,7 +293,12 @@ async fn upload_bulk_data(
 
     let mut headers = HeaderMap::new();
     let location = HeaderValue::from_str(&format!(
-        "{base_uri}/{entity_collection}/{entity_id}/bulk-data/{category}/{filename}"
+        "{}/{}/{}/bulk-data/{}/{}",
+        versioned_uri(&parts),
+        encode_path_segment(&entity_collection),
+        encode_path_segment(&entity_id),
+        encode_path_segment(&category),
+        encode_path_segment(&filename),
     ))
     .map_err(|e| BulkDataError::Internal(e.to_string()))?;
     headers.insert("Location", location);
@@ -302,7 +308,7 @@ async fn upload_bulk_data(
         headers,
         Json(Response {
             data: BulkDataUpload { id: filename },
-            schema: Some(BulkDataUpload::schema()),
+            schema: None,
         }),
     ))
 }

--- a/opensovd-server/src/routes/bulkdata.rs
+++ b/opensovd-server/src/routes/bulkdata.rs
@@ -11,6 +11,8 @@
 //! - GET /{entity-collection}/{entity-id}/bulk-data/{category}/{bulk-data-id} - Download a specific bulk data resource
 //! - DELETE /{entity-collection}/{entity-id}/bulk-data/{category}/{bulk-data-id} - Delete a specific bulk data resource
 
+use std::sync::Arc;
+
 use axum::{
     Json, Router,
     body::Body,
@@ -24,7 +26,7 @@ use axum_extra::{
     headers::{ContentLength, ContentType, Header},
 };
 use futures::StreamExt;
-use http::{HeaderName, HeaderValue, StatusCode};
+use http::{HeaderMap, HeaderName, HeaderValue, StatusCode, request::Parts};
 use opensovd_core::{BulkDataError, BulkDataProvider, CategoryFilter, Topology, TopologyReadGuard};
 use opensovd_models::{
     Response,
@@ -72,7 +74,7 @@ async fn bulk_data_categories(
     WithRejection(Query(query), _): WithRejection<Query<BulkDataCategoriesQuery>, Error>,
 ) -> Result<Json<Response<AvailableBulkDataCategories>>> {
     let topo = topology.read().await;
-    let provider = get_provider(&topo, &entity_collection, &entity_id)?;
+    let provider = get_provider(topo, &entity_collection, &entity_id)?;
     Ok(Json(Response {
         data: AvailableBulkDataCategories {
             items: provider
@@ -120,7 +122,7 @@ async fn bulk_data_descriptors(
     WithRejection(Query(query), _): WithRejection<Query<BulkDataDescriptorsQuery>, Error>,
 ) -> Result<Json<Response<BulkDataMetadata>>> {
     let topo = topology.read().await;
-    let provider = get_provider(&topo, &entity_collection, &entity_id)?;
+    let provider = get_provider(topo, &entity_collection, &entity_id)?;
 
     Ok(Json(Response {
         data: BulkDataMetadata {
@@ -211,6 +213,7 @@ impl Header for ContentDisposition {
 
 async fn upload_bulk_data(
     State(topology): State<Topology>,
+    parts: Parts,
     Path((entity_collection, entity_id, category)): Path<(String, String, String)>,
     WithRejection(TypedHeader(content_type), _): WithRejection<TypedHeader<ContentType>, Error>,
     WithRejection(TypedHeader(content_disposition), _): WithRejection<
@@ -219,15 +222,23 @@ async fn upload_bulk_data(
     >,
     WithRejection(TypedHeader(content_length), _): WithRejection<TypedHeader<ContentLength>, Error>,
     req: Request,
-) -> Result<(StatusCode, Json<Response<BulkDataUpload>>)> {
+) -> Result<(StatusCode, HeaderMap, Json<Response<BulkDataUpload>>)> {
     let topo = topology.read().await;
-    let provider = get_provider(&topo, &entity_collection, &entity_id)?;
+    let provider = get_provider(topo, &entity_collection, &entity_id)?;
 
+    let base_uri = super::base_uri(&parts);
     let filename = content_disposition
         .filename
         .clone()
         .or_else(|| content_disposition.name.clone())
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    if content_length.0 > MAX_BULKDATA_BODY_BYTES as u64 {
+        return Err(BulkDataError::InvalidRequest(format!(
+            "Content-Length exceeds maximum allowed size of {MAX_BULKDATA_BODY_BYTES} bytes",
+        ))
+        .into());
+    }
 
     if content_type == ContentType::octet_stream() {
         let mut stream = req
@@ -242,6 +253,7 @@ async fn upload_bulk_data(
             .await
             .map_err(|e| BulkDataError::InvalidRequest(e.to_string()))?;
         let mut sig = None;
+        let mut file_content_received = false;
         while let Some(field) = multipart
             .next_field()
             .await
@@ -262,18 +274,24 @@ async fn upload_bulk_data(
                     }
                 }
                 Some("application/octet-stream") => {
+                    // if the field has its own Content-Length header, we can
+                    // get a better estimate of the size of the data being
+                    // uploaded. Otherwise, we fall back to the Content-Length
+                    // header of the entire request.
+                    let length = field
+                        .headers()
+                        .get("Content-Length")
+                        .and_then(|v| v.to_str().ok())
+                        .and_then(|s| s.parse::<u64>().ok())
+                        .unwrap_or(content_length.0);
                     let mut data_stream = field.map(|chunk| {
                         chunk.map_err(|e| BulkDataError::InvalidRequest(e.to_string()))
                     });
                     provider
-                        .upload(
-                            &category,
-                            &filename,
-                            content_length.0,
-                            &mut data_stream,
-                            sig.as_ref(),
-                        )
+                        .upload(&category, &filename, length, &mut data_stream, sig.as_ref())
                         .await?;
+                    file_content_received = true;
+                    break;
                 }
                 _ => {
                     return Err(BulkDataError::InvalidRequest(
@@ -283,13 +301,26 @@ async fn upload_bulk_data(
                 }
             }
         }
+        if !file_content_received {
+            return Err(
+                BulkDataError::InvalidRequest("no file content received".to_string()).into(),
+            );
+        }
     }
+
+    let mut headers = HeaderMap::new();
+    let location = HeaderValue::from_str(&format!(
+        "{base_uri}/{entity_collection}/{entity_id}/bulk-data/{category}/{filename}"
+    ))
+    .map_err(|e| BulkDataError::Internal(e.to_string()))?;
+    headers.insert("Location", location);
 
     Ok((
         StatusCode::CREATED,
+        headers,
         Json(Response {
-            data: BulkDataUpload { id: entity_id },
-            schema: Some(Vec::<BulkDataUpload>::schema()),
+            data: BulkDataUpload { id: filename },
+            schema: Some(BulkDataUpload::schema()),
         }),
     ))
 }
@@ -299,7 +330,7 @@ async fn delete_bulk_data_category(
     Path((entity_collection, entity_id, category)): Path<(String, String, String)>,
 ) -> Result<StatusCode> {
     let topo = topology.read().await;
-    let provider = get_provider(&topo, &entity_collection, &entity_id)?;
+    let provider = get_provider(topo, &entity_collection, &entity_id)?;
 
     provider.delete(&category, None).await?;
 
@@ -316,7 +347,7 @@ async fn download_bulk_data(
     )>,
 ) -> Result<impl IntoResponse> {
     let topo = topology.read().await;
-    let provider = get_provider(&topo, &entity_collection, &entity_id)?;
+    let provider = get_provider(topo, &entity_collection, &entity_id)?;
 
     let bulkdata = provider.download(&category, &bulk_data_id).await?;
 
@@ -347,19 +378,19 @@ async fn delete_bulk_data(
     )>,
 ) -> Result<StatusCode> {
     let topo = topology.read().await;
-    let provider = get_provider(&topo, &entity_collection, &entity_id)?;
+    let provider = get_provider(topo, &entity_collection, &entity_id)?;
 
     provider.delete(&category, Some(&bulk_data_id)).await?;
 
     Ok(StatusCode::NO_CONTENT)
 }
 
-fn get_provider<'a>(
-    topo: &'a TopologyReadGuard<'a>,
+fn get_provider(
+    topo: TopologyReadGuard,
     entity_collection: &str,
     entity_id: &str,
-) -> Result<&'a dyn BulkDataProvider> {
-    match entity_collection {
+) -> Result<Arc<dyn BulkDataProvider>> {
+    let provider = match entity_collection {
         "components" => {
             let component = topo
                 .get_component(entity_id)
@@ -376,5 +407,7 @@ fn get_provider<'a>(
                 .ok_or_else(|| Error::ProviderNotAvailable("bulkdata".into()))
         }
         _ => Err(Error::EntityNotFound(entity_collection.to_string())),
-    }
+    };
+    drop(topo);
+    provider
 }

--- a/opensovd-server/src/routes/entities/app.rs
+++ b/opensovd-server/src/routes/entities/app.rs
@@ -97,6 +97,10 @@ pub(super) async fn app_capabilities(
         .data_provider()
         .map(|_| format!("{base}/apps/{}/data", encode_path_segment(&app_id)).into());
 
+    let bulk_data = entity
+        .bulkdata_provider()
+        .map(|_| format!("{base}/apps/{}/bulk-data", encode_path_segment(&app_id)).into());
+
     Ok(Json(Response {
         data: EntityCapabilities {
             id: app_id,
@@ -106,6 +110,7 @@ pub(super) async fn app_capabilities(
             is_located_on,
             belongs_to,
             data,
+            bulk_data,
             ..Default::default()
         },
         schema: query.include_schema.then(EntityCapabilities::schema),

--- a/opensovd-server/src/routes/entities/component.rs
+++ b/opensovd-server/src/routes/entities/component.rs
@@ -111,6 +111,14 @@ pub(super) async fn component_capabilities(
         .into()
     });
 
+    let bulk_data = entity.bulkdata_provider().map(|_| {
+        format!(
+            "{base}/components/{}/bulk-data",
+            encode_path_segment(&component_id)
+        )
+        .into()
+    });
+
     Ok(Json(Response {
         data: EntityCapabilities {
             id: component_id,
@@ -120,6 +128,7 @@ pub(super) async fn component_capabilities(
             hosts,
             belongs_to,
             data,
+            bulk_data,
             ..Default::default()
         },
         schema: query.include_schema.then(EntityCapabilities::schema),

--- a/opensovd-server/src/routes/error.rs
+++ b/opensovd-server/src/routes/error.rs
@@ -9,8 +9,8 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Json, Response},
 };
-use axum_extra::extract::QueryRejection;
-use opensovd_core::{DataError, TopologyError};
+use axum_extra::{extract::QueryRejection, typed_header::TypedHeaderRejection};
+use opensovd_core::{BulkDataError, DataError, TopologyError};
 use opensovd_models::{ErrorCode, GenericError};
 
 /// A `Result` alias where the `Err` variant is [`Error`].
@@ -25,8 +25,12 @@ pub enum Error {
     ProviderNotAvailable(String),
     #[error(transparent)]
     Data(#[from] DataError),
+    #[error(transparent)]
+    BulkData(#[from] BulkDataError),
     #[error("{0}")]
     BadQuery(#[from] QueryRejection),
+    #[error("{0}")]
+    InvalidHeader(#[from] TypedHeaderRejection),
     #[error(transparent)]
     Topology(#[from] TopologyError),
 }
@@ -66,9 +70,32 @@ impl IntoResponse for Error {
 
                 (status, GenericError::new(ErrorCode::ErrorResponse, message))
             }
+            Self::BulkData(e) => {
+                let status = match e {
+                    BulkDataError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+                    BulkDataError::DeletionFailed(_) => StatusCode::CONFLICT,
+                    BulkDataError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
+                    BulkDataError::NotFound(_) => StatusCode::NOT_FOUND,
+                };
+
+                // Sanitize internal errors - log details, return generic message
+                let message = match e {
+                    BulkDataError::Internal(msg) => {
+                        tracing::error!(target: "srv", error = %msg, "Internal error");
+                        "An internal error occurred".to_string()
+                    }
+                    _ => e.to_string(),
+                };
+
+                (status, GenericError::new(ErrorCode::ErrorResponse, message))
+            }
             Self::BadQuery(_) => (
                 StatusCode::BAD_REQUEST,
                 GenericError::new(ErrorCode::IncompleteRequest, "Bad request"),
+            ),
+            Self::InvalidHeader(_) => (
+                StatusCode::BAD_REQUEST,
+                GenericError::new(ErrorCode::IncompleteRequest, "Bad request headers"),
             ),
             Self::Topology(e) => {
                 let status = match e {

--- a/opensovd-server/src/routes/mod.rs
+++ b/opensovd-server/src/routes/mod.rs
@@ -10,6 +10,14 @@
 //! - GET /components - List all components
 //! - GET /components/{component_id} - Query capabilities of a component
 //!
+//! ## Bulkdata
+//! - GET    /{entity-collection}/{entity-id}/bulk-data - List bulk-data categories
+//! - GET    /{entity-collection}/{entity-id}/bulk-data/{category} - List of BulkDataDescriptors for a specific category
+//! - POST   /{entity-collection}/{entity-id}/bulk-data/{category} - Upload bulk data to the SOVD server and create a resource for the bulk data
+//! - DELETE /{entity-collection}/{entity-id}/bulk-data/{category} - Delete all bulk data resources for a specific category
+//! - GET    /{entity-collection}/{entity-id}/bulk-data/{category}/{bulk-data-id} - Download a specific bulk data resource
+//! - DELETE /{entity-collection}/{entity-id}/bulk-data/{category}/{bulk-data-id} - Delete a specific bulk data resource
+//!
 //! ## Data
 //! - GET /components/{component_id}/data-categories - List data categories
 //! - GET /components/{component_id}/data-groups - List data groups
@@ -20,6 +28,7 @@
 //! ## Version
 //! - GET /version-info - Get SOVD server version information
 
+mod bulkdata;
 mod data;
 mod entities;
 mod error;
@@ -106,6 +115,7 @@ where
 
     let v1_routes = Router::new()
         .merge(entities::routes::<V>())
+        .merge(bulkdata::routes::<V>())
         .merge(data::routes::<V>());
 
     let router = Router::new()

--- a/tests/opensovd-gateway/mocks/test_bulkdata.py
+++ b/tests/opensovd-gateway/mocks/test_bulkdata.py
@@ -192,6 +192,43 @@ def test_delete_category_removes_all_entries(client):
 
 
 # ---------------------------------------------------------------------------
+# Tests: undeletable (permanent) entries
+# ---------------------------------------------------------------------------
+
+PERMANENT_CATEGORY = "logs"
+PERMANENT_ID = "cannot_delete"
+
+
+def test_delete_permanent_entry_returns_409(client):
+    """Deleting the protected logs entry is rejected with 409 Conflict."""
+    resp = client.delete(f"{BASE}/{PERMANENT_CATEGORY}/{PERMANENT_ID}")
+    assert resp.status_code == 409, f"unexpected status: {resp.status_code} {resp.text}"
+
+    ids = [item["id"] for item in client.get(f"{BASE}/{PERMANENT_CATEGORY}").json()["items"]]
+    assert PERMANENT_ID in ids, f"protected entry disappeared: {ids}"
+
+
+def test_delete_permanent_category_is_partial_success(client):
+    """Deleting the logs category removes uploads but reports the protected entry."""
+    _upload(client, PERMANENT_CATEGORY, "boot.log", b"boot")
+    _upload(client, PERMANENT_CATEGORY, "kernel.log", b"kernel")
+
+    resp = client.delete(f"{BASE}/{PERMANENT_CATEGORY}")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert sorted(body["deleted_ids"]) == ["boot.log", "kernel.log"], (
+        f"unexpected deleted ids: {body['deleted_ids']}"
+    )
+    errors = {err["id"]: err["error"] for err in body["errors"]}
+    assert PERMANENT_ID in errors, f"expected error for {PERMANENT_ID}: {body['errors']}"
+    assert errors[PERMANENT_ID].get("vendor_code") == "unable-to-delete"
+
+    ids = [item["id"] for item in client.get(f"{BASE}/{PERMANENT_CATEGORY}").json()["items"]]
+    assert ids == [PERMANENT_ID], f"expected only the protected entry, got {ids}"
+
+
+# ---------------------------------------------------------------------------
 # Tests: error paths
 # ---------------------------------------------------------------------------
 

--- a/tests/opensovd-gateway/mocks/test_bulkdata.py
+++ b/tests/opensovd-gateway/mocks/test_bulkdata.py
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Contributors to the Eclipse Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gateway integration tests for the bulk-data endpoints.
+
+Uses the ``--mock`` topology which exposes the ``ota_manager`` app backed
+by an in-memory bulk-data provider.  Tests cover: API traversal, category
+listing, list with filter parameters, multipart upload + download roundtrip,
+single-file and category-level delete, missing-provider 404, and
+malformed-multipart rejection.
+"""
+
+BULK_DATA_HOST = "ota_manager"
+BASE = f"/v1/apps/{BULK_DATA_HOST}/bulk-data"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_multipart(filename: str, content: bytes) -> tuple[bytes, str]:
+    """Return ``(body, boundary)`` for a single-part octet-stream upload."""
+    boundary = b"opensovdboundary"
+    body = (
+        b"--" + boundary + b"\r\n"
+        b"Content-Type: application/octet-stream\r\n"
+        b"\r\n" + content + b"\r\n"
+        b"--" + boundary + b"--\r\n"
+    )
+    return body, boundary.decode()
+
+
+def _upload(client, category: str, filename: str, content: bytes) -> None:
+    """POST a multipart binary upload and assert 201 Created."""
+    body, boundary = _build_multipart(filename, content)
+    resp = client.http.request(
+        "POST",
+        f"{BASE}/{category}",
+        content=body,
+        headers={
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Content-Length": str(len(body)),
+        },
+    )
+    assert resp.status_code == 201, f"upload failed: {resp.status_code} {resp.text}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: API traversal includes bulk-data link
+# ---------------------------------------------------------------------------
+
+
+def test_traversal_includes_bulk_data_link(client):
+    """App capabilities response includes a bulk-data link for the OTA manager."""
+    resp = client.get(f"/v1/apps/{BULK_DATA_HOST}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "bulk-data" in body, f"missing bulk-data in capabilities: {list(body.keys())}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: categories endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_categories_after_upload(client):
+    """After uploading a file a category entry appears in the listing."""
+    category = "cat-after-upload"
+    _upload(client, category, "fw.bin", b"bytes")
+
+    resp = client.get(BASE)
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert category in items, f"expected {category!r} in categories {items}"
+
+
+def test_categories_missing_provider_returns_404(client):
+    """Requesting bulk-data for an entity without a provider returns 404."""
+    resp = client.get("/v1/components/ecu/bulk-data")
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body.get("vendor_code") == "provider-not-available"
+
+
+# ---------------------------------------------------------------------------
+# Tests: list (descriptors) endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_list_returns_uploaded_descriptor(client):
+    """Uploaded file descriptor appears in the category listing."""
+    category = "cat-list-descriptor"
+    _upload(client, category, "desc-test.bin", b"descriptor-test")
+
+    resp = client.get(f"{BASE}/{category}")
+    assert resp.status_code == 200
+    ids = [item["id"] for item in resp.json()["items"]]
+    assert "desc-test.bin" in ids, f"expected desc-test.bin in {ids}"
+
+
+def test_list_with_tags_query_parameter(client):
+    """tags query parameter is accepted without error."""
+    category = "cat-list-tags"
+    _upload(client, category, "tagged.bin", b"data")
+
+    resp = client.get(f"{BASE}/{category}", params={"tags": "sensor"})
+    assert resp.status_code == 200
+
+
+def test_list_with_date_filter_parameters(client):
+    """created-before and created-after are accepted without error."""
+    category = "cat-list-dates"
+    _upload(client, category, "dated.bin", b"data")
+
+    resp = client.get(
+        f"{BASE}/{category}",
+        params={
+            "created-before": "2099-01-01T00:00:00Z",
+            "created-after": "2000-01-01T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+
+
+def test_list_invalid_date_returns_400(client):
+    """An unparseable date in created-before returns 400."""
+    resp = client.get(f"{BASE}/any-cat", params={"created-before": "not-a-date"})
+    assert resp.status_code == 400
+
+
+def test_list_with_include_schema(client):
+    """include-schema=true returns a schema object alongside items."""
+    category = "cat-list-schema"
+    _upload(client, category, "schema.bin", b"data")
+
+    resp = client.get(f"{BASE}/{category}", params={"include-schema": "true"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "schema" in body, "expected schema key when include-schema=true"
+
+
+# ---------------------------------------------------------------------------
+# Tests: upload → download roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_upload_and_download_roundtrip(client):
+    """Uploading binary data then downloading it returns the exact same bytes."""
+    payload = b"\x00\x01\x02\x03binary-content"
+    category = "cat-roundtrip"
+    filename = "roundtrip.bin"
+    _upload(client, category, filename, payload)
+
+    resp = client.get(f"{BASE}/{category}/{filename}")
+    assert resp.status_code == 200
+    assert resp.content == payload, (
+        f"downloaded content mismatch: got {resp.content!r}, expected {payload!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: delete endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_delete_single_file_removes_descriptor(client):
+    """Deleting a single file removes it from the descriptor list."""
+    category = "cat-delete-single"
+    _upload(client, category, "delete-me.bin", b"to-be-deleted")
+
+    del_resp = client.delete(f"{BASE}/{category}/delete-me.bin")
+    assert del_resp.status_code == 204
+
+    ids = [item["id"] for item in client.get(f"{BASE}/{category}").json()["items"]]
+    assert "delete-me.bin" not in ids, f"file still present after delete: {ids}"
+
+
+def test_delete_category_removes_all_entries(client):
+    """Deleting a category removes all its files but leaves other categories intact."""
+    _upload(client, "cat-to-delete", "f1.bin", b"f1")
+    _upload(client, "cat-to-delete", "f2.bin", b"f2")
+    _upload(client, "keeper-cat", "keep.bin", b"keep")
+
+    del_resp = client.delete(f"{BASE}/cat-to-delete")
+    assert del_resp.status_code == 200
+
+    cats = client.get(BASE).json()["items"]
+    assert "cat-to-delete" not in cats, f"deleted category still present: {cats}"
+    assert "keeper-cat" in cats, f"keeper category missing: {cats}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: error paths
+# ---------------------------------------------------------------------------
+
+
+def test_upload_malformed_missing_content_type_returns_400(client):
+    """POST without a Content-Type header is rejected with 400."""
+    resp = client.http.request(
+        "POST",
+        f"{BASE}/any-cat",
+        content=b"raw-body",
+    )
+    assert resp.status_code == 400
+
+
+def test_download_nonexistent_file_returns_400(client):
+    """Downloading a file that does not exist returns 404 (Not Found)."""
+    resp = client.get(f"{BASE}/any-cat/no-such-file.bin")
+    assert resp.status_code == 404
+
+
+def test_upload_direct_octet_stream_roundtrip(client):
+    """Uploading raw bytes as application/octet-stream (no multipart) succeeds."""
+    payload = b"direct-upload-content"
+    category = "cat-direct-upload"
+    filename = "direct.bin"
+
+    resp = client.http.request(
+        "POST",
+        f"{BASE}/{category}",
+        content=payload,
+        headers={
+            "Content-Type": "application/octet-stream",
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Content-Length": str(len(payload)),
+        },
+    )
+    assert resp.status_code == 201, f"upload failed: {resp.status_code} {resp.text}"
+
+    dl = client.get(f"{BASE}/{category}/{filename}")
+    assert dl.status_code == 200
+    assert dl.content == payload

--- a/tests/opensovd-gateway/mocks/test_bulkdata.py
+++ b/tests/opensovd-gateway/mocks/test_bulkdata.py
@@ -206,7 +206,7 @@ def test_upload_malformed_missing_content_type_returns_400(client):
     assert resp.status_code == 400
 
 
-def test_download_nonexistent_file_returns_400(client):
+def test_download_nonexistent_file_returns_404(client):
     """Downloading a file that does not exist returns 404 (Not Found)."""
     resp = client.get(f"{BASE}/any-cat/no-such-file.bin")
     assert resp.status_code == 404


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

These changes add support for bulk-data resources in opensovd. This includes (commits are structured accordingly):

* changes to opensovd-models to add a BulkDataDescriptor struct and helper types for bulk data requests and responses
* a bulk data provider trait in opensovd-core
* necessary wiring to make the bulk-data provider available in component and app entities
* routes  that implement the SOVD bulk-data endpoints
* an example program to showcase, how the bulk-data provider can be implemented
* a bulk-data mock provider in opensovd-mocks that is added to the demo-topology
* python and rust tests

## Checklist

- [x] I have tested my changes locally
- [x] I have linked related issues or discussions
- [x] I have added or updated tests

## Related

Closes #163


## Notes for Reviewers

The maximum request body size was increased to 1GiB, so large files can be uploaded to bulk-data.
